### PR TITLE
create workflow based on zeels dark desires

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Release Creation
+
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # get part of the tag after the `v`
+    - name: Extract tag version number
+      id: get_version
+      uses: battila7/get-version-action@v2
+
+    - name: Echo tag output
+      run: echo ${{ steps.get_version.outputs.version-without-v }}
+
+    # Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link_version
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        version: ${{steps.get_version.outputs.version-without-v}}
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{steps.get_version.outputs.version-without-v}}/module.zip
+
+    # Create a zip file with all files required by the module to add to the release
+    - run: zip -r ./module.zip module.json monsterblock.js monsterblock.css actor-sheet.html lang/ input-expressions/handler.js
+
+    # Create a release for this specific version
+    - name: Update Release with Files
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
+        name: ${{ github.event.release.name }}
+        draft: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json, ./module.zip'
+        tag: ${{ github.event.release.tag_name }}
+        body: ${{ github.event.release.body }}

--- a/module.json
+++ b/module.json
@@ -44,7 +44,7 @@
 			"manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/mathjs-lib/master/module.json"
 		}
 	],
-	"manifest": "https://raw.githubusercontent.com/zeel01/MonsterBlocks/master/module.json",
+	"manifest": "https://github.com/zeel01/MonsterBlocks/releases/latest/download/module.json",
 	"url": "https://github.com/zeel01/MonsterBlocks",
 	"download": "https://github.com/zeel01/MonsterBlocks/releases/download/v2.4.2/monsterblock.zip",
 	"readme": "https://github.com/zeel01/MonsterBlocks/blob/master/readme.md",


### PR DESCRIPTION
When a new tag is pushed run a GH Action that:
1. Gets the tag and puts it into the `download` and `version` fields of the manifest
2. zips up all the relevant files
3. attaches those files to a draft release

This means you can delete your gulpfile, package.json and package-lock when you feel comfortable doing so.