### PR TITLE
Fix whitespace after versatile attacks

### DIFF
--- a/actor-sheet.html
+++ b/actor-sheet.html
@@ -886,8 +886,8 @@
 										damage=item.description.versatile.text
 								)
 							}}
+							{{~#unless @last}}{{ localize "MOBLOKS5E.Comma" }}{{/unless~}}
 						{{/if}}
-						{{~#unless @last}}{{ localize "MOBLOKS5E.Comma" }}{{/unless}}
 						{{~#if @last}}{{ localize "MOBLOKS5E.FullStop" }}{{/if}}
 					{{/each}}			
 				{{/if}}

--- a/actor-sheet.html
+++ b/actor-sheet.html
@@ -886,8 +886,8 @@
 										damage=item.description.versatile.text
 								)
 							}}
-							{{~#unless @last}}{{ localize "MOBLOKS5E.Comma" }}{{/unless}}
 						{{/if}}
+						{{~#unless @last}}{{ localize "MOBLOKS5E.Comma" }}{{/unless}}
 						{{~#if @last}}{{ localize "MOBLOKS5E.FullStop" }}{{/if}}
 					{{/each}}			
 				{{/if}}


### PR DESCRIPTION
This fixes issue #47 , and the whitespace that appears after versatile attacks. Also adds the comma between each additional damage type.
![image](https://user-images.githubusercontent.com/7407481/108083243-e0ffa400-7040-11eb-86e9-b3a1160aa7d1.png)