### PR TITLE
Handle continued damage text

### DIFF
--- a/actor-sheet.html
+++ b/actor-sheet.html
@@ -853,7 +853,7 @@
 			{{~/if~}}
 			{{ localize "MOBLOKS5E.NameDescriptionSep" }}
 			{{#if @root.flags.attack-descriptions}}
-			<span class="generated-text">			
+			<span class="generated-text">
 				<span class="attack-bonus" 
 					data-roll-flavor="{{localize 'DND5E.Attack'}}: {{item.name}}" 
 					data-roll-formula="1d20 + {{item.tohit}}">
@@ -873,7 +873,7 @@
 					</span>
 					{{#each item.description.damage as |part|}}
 						{{#unless @first}}
-							{{ localize "MOBLOKS5E.MultiDamageAttackConjunctionPlus" }}						
+							{{ localize "MOBLOKS5E.MultiDamageAttackConjunctionPlus" }}
 						{{/unless}}
 						{{> damageRoll text=part.text name=item.name formula=part.formula}}
 						{{ localize "MOBLOKS5E.damage" }}
@@ -882,17 +882,17 @@
 							{{> damageRoll 
 								name=item.name 
 								formula=item.description.versatile.formula
-								text=(	localize "MOBLOKS5E.AttackVersatile"
+								text=( localize "MOBLOKS5E.AttackVersatile"
 										damage=item.description.versatile.text
 								)
 							}}
 							{{~#unless @last}}{{ localize "MOBLOKS5E.Comma" }}{{/unless~}}
 						{{/if}}
-						{{~#if @last}}{{ localize "MOBLOKS5E.FullStop" }}{{/if}}
-					{{/each}}			
-				{{/if}}
+					{{/each}}
+				{{/if~}}
 			</span>
-			{{/if}}
+			{{~/if}}
+			{{~#unless (moblok-moretext item.data.description.value) }}{{~localize "MOBLOKS5E.Continue"}}{{/unless~}}
 			<span class="description">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</span>
 		</div>
 	</section>

--- a/lang/en.json
+++ b/lang/en.json
@@ -136,6 +136,7 @@
 	"MOBLOKS5E.nine": "nine",
 	
 	"MOBLOKS5E.FullStop": ".",
+	"MOBLOKS5E.Continue": ". ",
 	"MOBLOKS5E.NameDescriptionSep": ".",
 	"MOBLOKS5E.SpeedUnitAbbrEnd": ".",
 	"MOBLOKS5E.Comma": ",",

--- a/monsterblock.js
+++ b/monsterblock.js
@@ -1693,6 +1693,10 @@ export class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
+		},
+		"moblok-moretext": (desc) => { // Checks if description text starts with a space or a comma.
+			if (desc === null) return false;
+			return desc.startsWith('\s', desc.indexOf('>') + 1) || desc.startsWith(',', desc.indexOf('>') + 1);
 		}
 	};
 }

--- a/monsterblock.js
+++ b/monsterblock.js
@@ -1696,7 +1696,7 @@ export class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-moretext": (desc) => { // Checks if description text starts with a space or a comma.
 			if (desc === null) return false;
-			return desc.startsWith('\s', desc.indexOf('>') + 1) || desc.startsWith(',', desc.indexOf('>') + 1);
+			return desc.startsWith('\s', desc.indexOf('>') + 1) || desc.startsWith('&nbsp;', desc.indexOf('>') + 1) || desc.startsWith(',', desc.indexOf('>') + 1);
 		}
 	};
 }


### PR DESCRIPTION
The following are changes for issue #48 that handle supporting additional text after weapon damage has been displayed. This includes starting the text with a comma or whitespace. This will then forgo the period and instead continue the inline text.
The following are multiple weapon examples showing the different variations.
![image](https://user-images.githubusercontent.com/7407481/108608629-41227d00-7396-11eb-86ab-1139bac12c66.png)