### PR TITLE
Support Tokenizer 3.3.4

### DIFF
--- a/monsterblock.js
+++ b/monsterblock.js
@@ -13,7 +13,6 @@ Hooks.once("init", () => {
 });
 
 Hooks.once("ready", () => {
-	MonsterBlock5e.getTokenizer();
 	MonsterBlock5e.getQuickInserts();
 	
 	MonsterBlock5e.preLoadTemplates();

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -435,7 +435,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	}
 	async openTokenizer() {
 		if (this.constructor.Tokenizer) {
-			new this.constructor.Tokenizer({}, this.entity).render(true);
+			Tokenizer.tokenizeActor(this.entity);
 		}
 	}
 	async resetDefaults() {

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -101,7 +101,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			hasLair: Boolean(data.features.lair.items.length),
 			hasReactions: Boolean(data.features.reaction.items.length),
 			hasLoot: Boolean(data.features.equipment.items.length),
-			vttatokenizer: Boolean(Tokenizer)
+			vttatokenizer: Boolean(window.Tokenizer)
 		}
 		data.menus = this.menuTrees;
 		Object.values(this.menuTrees).forEach(m => m.update(m, data));
@@ -435,7 +435,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	}
 	async openTokenizer() {
 		/* global Tokenizer */
-		if (Tokenizer) {
+		if (window.Tokenizer) {
 			Tokenizer.tokenizeActor(this.object);
 		}
 	}

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -101,7 +101,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			hasLair: Boolean(data.features.lair.items.length),
 			hasReactions: Boolean(data.features.reaction.items.length),
 			hasLoot: Boolean(data.features.equipment.items.length),
-			vttatokenizer: Boolean(this.constructor.Tokenizer)
+			vttatokenizer: Boolean(Tokenizer)
 		}
 		data.menus = this.menuTrees;
 		Object.values(this.menuTrees).forEach(m => m.update(m, data));
@@ -434,8 +434,9 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		});
 	}
 	async openTokenizer() {
-		if (this.constructor.Tokenizer) {
-			Tokenizer.tokenizeActor(this.entity);
+		/* global Tokenizer */
+		if (Tokenizer) {
+			Tokenizer.tokenizeActor(this.object);
 		}
 	}
 	async resetDefaults() {
@@ -659,15 +660,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			"compact-layout": game.settings.get("monsterblock", "compact-layout"),
 			"font-size": game.settings.get("monsterblock", "font-size")
 		});
-	}
-	static async getTokenizer() {
-		if (game.data.modules.find(m => m.id == "vtta-tokenizer")?.active) {
-			let Tokenizer = (await import("../../../vtta-tokenizer/src/tokenizer/index.js")).default;
-			Object.assign(this, { Tokenizer });
-		}
-		else {
-			this.Tokenizer = false;
-		}
 	}
 	static async getQuickInserts() {
 		if (game.data.modules.find(m => m.id == "quick-insert")?.active) {


### PR DESCRIPTION
As of Tokenizer 3.3.0 the constructor has changed. As of 3.3.4 I expose a new function on Tokenizer window to allow actors to be passed to Tokenizer. I suspect there is also some additional cleanup that can be done else where in the code.