### PR TITLE
Use `systems` rather than `system` in the manifest

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,7 +14,7 @@
 	"version": "3.1.0",
 	"minimumCoreVersion": "0.8.8",
 	"compatibleCoreVersion": "0.8.9",
-	"systems": ["dnd5e"],
+	"system": ["dnd5e"],
 	"minimumSystemVersion": "1.4.0",
 	"scripts": [
 		"input-expressions/handler.js"


### PR DESCRIPTION
Fixes #108