### PR TITLE
Evaluate attack roll expressions before simplifying

### DIFF
--- a/scripts/dnd5e/AttackPreper.js
+++ b/scripts/dnd5e/AttackPreper.js
@@ -246,7 +246,8 @@ export default class AttackPreper extends ItemPreper {
 	 * @memberof AttackPreper
 	 */
 	damageFormula(index=0) {	// Extract and re-format the damage formula
-		return simplifyRollFormula(this.getAttackFormula(index), this.item.getRollData());
+		const roll = new Roll(this.getAttackFormula(index), this.item.getRollData());
+		return simplifyRollFormula(roll.formula);
 	}
 
 	/**


### PR DESCRIPTION
In response to [this DnD 5e MR](https://gitlab.com/foundrynet/dnd5e/-/merge_requests/428) (merged in 1.5.2), it is necessary to evaluate roll expressions before passing them to `simplifyRollFormula()`. This expands terms like `@mod` to their numeric value before simplification. Otherwise, with the new `simplifyRollFormula()` that does not use the roll data, those terms get expanded to 0 and dropped.

Fixes #123 