### PR TITLE
Tokenizer call correction

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -437,7 +437,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	async openTokenizer() {
 		/* global Tokenizer */
 		if (window.Tokenizer) {
-			Tokenizer.tokenizeActor(this.object);
+			window.Tokenizer.tokenizeActor(this.object);
 		}
 	}
 	async resetDefaults() {


### PR DESCRIPTION
Advanced Macros exposes a class called Tokenizer, which gets loaded before vtta-tokenizer. Therefore call Tokenizers window binding rather than relying on the class being available to instantiate.

Thanks!