### PR TITLE
Resolves Issue Quick Insert Fails #137

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -273,7 +273,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			restrictTypes: ["Item"],
 			onSubmit: async (item) => {
 				const theItem = await fromUuid(item.uuid);
-				this.actor.createEmbeddedDocuments("Item", [theItem]);
+				this.actor.createEmbeddedDocuments("Item", [theItem.data]);
 			}
 		});
 	}


### PR DESCRIPTION
The object for `createEmbeddedDocuments()` requires the data object from an item, not the item itself.