### PR TITLE
Resolves issue #61 - Bonus Action Section

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -266,6 +266,7 @@
 		"damage": "damage",
 		
 		"Reactions": "Reactions",
+		"BonusActions": "Bonus Actions",
 		"Multiattack": "Multiattack",
 		"LegendaryResistance": "Legendary Resistance",
 		

--- a/scripts/dnd5e/ActionPreper.js
+++ b/scripts/dnd5e/ActionPreper.js
@@ -31,6 +31,7 @@ export default class ActionPreper extends ItemPreper {
 			legendary:    MonsterBlock5e.isLegendaryAction(data),
 			lair:         MonsterBlock5e.isLairAction(data),
 			legResist:    MonsterBlock5e.isLegendaryResistance(data),
+			bonusAction:  MonsterBlock5e.isBonusAction(data),
 			reaction:     MonsterBlock5e.isReaction(data)
 		};
 		is.specialAction = this.isSpecialAction(is);

--- a/scripts/dnd5e/ItemPrep.js
+++ b/scripts/dnd5e/ItemPrep.js
@@ -45,6 +45,7 @@ export default class ItemPrep {
 		multiattack:{ prep: ActionPreper,  filter: MonsterBlock5e.isMultiAttack,                 label: game.i18n.localize("MOBLOKS5E.Multiattack"),         items: [], dataset: {type: "feat"}   },
 		casting:	{ prep: CastingPreper, filter: CastingPreper.isCasting.bind(CastingPreper),  label: game.i18n.localize("DND5E.Features"),                items: [], dataset: {type: "feat"}   },
 		reaction:	{ prep: ActionPreper,  filter: MonsterBlock5e.isReaction,                    label: game.i18n.localize("MOBLOKS5E.Reactions"),           items: [], dataset: {type: "feat"}   },
+		bonusActions: {prep: ActionPreper, filter: MonsterBlock5e.isBonusAction,                 label: game.i18n.localize("MOBLOKS5E.BonusActions"),        items: [], dataset: {type: "feat"}   },
 		attacks:	{ prep: AttackPreper,  filter: item => item.type === "weapon",               label: game.i18n.localize("DND5E.AttackPl"),                items: [], dataset: {type: "weapon"} },
 		actions:	{ prep: ActionPreper,  filter: item => Boolean(item.data?.activation?.type), label: game.i18n.localize("DND5E.ActionPl"),                items: [], dataset: {type: "feat"}   },
 		features:	{ prep: ItemPreper,    filter: item => item.type === "feat",                 label: game.i18n.localize("DND5E.Features"),                items: [], dataset: {type: "feat"}   },

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -100,6 +100,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			hasAtWillSpells: this.hasAtWillSpells(),
 			hasLegendaryActions: Boolean(data.features.legendary.items.length),
 			hasLair: Boolean(data.features.lair.items.length),
+			hasBonusActions: Boolean(data.features.bonusActions.items.length),
 			hasReactions: Boolean(data.features.reaction.items.length),
 			hasLoot: Boolean(data.features.equipment.items.length),
 			vttatokenizer: Boolean(window.Tokenizer)
@@ -417,6 +418,11 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	hasAtWillSpells() {	// Some normal casters also have a few spells that they can cast "At will"
 		return this.actor.data.items.some((item) => {
 			return item.data.preparation?.mode === "atwill";
+		});
+	}
+	hasBonusActions() {
+		return this.actor.data.items.some((item) => {
+			return this.constructor.isBonusAction(item);
 		});
 	}
 	hasReactions() {
@@ -1158,6 +1164,10 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	
 	static isLairAction(item) {
 		return item.data?.activation?.type === "lair";
+	}
+
+	static isBonusAction(item) {
+		return item.data?.activation?.type === "bonus";
 	}
 	
 	static isReaction(item) {

--- a/templates/dnd5e/main.hbs
+++ b/templates/dnd5e/main.hbs
@@ -47,6 +47,16 @@
 			{{/unless}}
 		{{/each}}
 
+		{{! Bonus Actions }}
+		{{#if info.hasBonusActions}}
+			<h2 class="section-header">{{localize "MOBLOKS5E.BonusActions"}}</h2>
+			{{#each features.bonusActions.items as |item iid|}}
+				{{#if item.is.bonusAction}}
+					{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor flags=@root.flags}}
+				{{/if}}
+			{{/each}}
+		{{/if}}		
+
 	{{! Reactions }}
 		{{#if info.hasReactions}}
 			<h2 class="section-header">{{localize "MOBLOKS5E.Reactions"}}</h2>


### PR DESCRIPTION
This pull adds a bonus action section between standard actions and reactions according the new style changes for the NPC statblock. I can't find the documentation where it stated between Actions and Reactions right now, but I do know that's where they placed it.