### PR TITLE
Resolves issue #145

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -203,6 +203,7 @@
 		"ProfBonus": "Proficiency Bonus",
 
 		"EditHint": "Right-click to edit",
+		"EditButtonHint": "Click the + button above to add features",
 
 		"AddFeat": "Feature",
 		"AddAttack": "Attack",

--- a/monsterblock.css
+++ b/monsterblock.css
@@ -427,6 +427,11 @@
 	visibility: visible;
 }
 
+.monsterblock .menu-hint {
+	text-align: right;
+	font-style: italic;
+}
+
 .monsterblock .delete-item {
 	/* display: none; */
 	visibility: hidden;

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -100,6 +100,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			hasAtWillSpells: this.hasAtWillSpells(),
 			hasLegendaryActions: Boolean(data.features.legendary.items.length),
 			hasLair: Boolean(data.features.lair.items.length),
+			hasActions: Boolean(data.features.attacks.items.length || data.features.actions.items.length),
 			hasBonusActions: Boolean(data.features.bonusActions.items.length),
 			hasReactions: Boolean(data.features.reaction.items.length),
 			hasLoot: Boolean(data.features.equipment.items.length),

--- a/templates/dnd5e/main.hbs
+++ b/templates/dnd5e/main.hbs
@@ -26,7 +26,9 @@
 		{{/if}}
 
 	{{! Actions }}
-		<h2 class="section-header" >{{localize "DND5E.ActionPl"}}</h2>
+		{{#if info.hasActions}}
+			<h2 class="section-header" >{{localize "DND5E.ActionPl"}}</h2>
+		{{/if}}
 
 		{{! Multiattack }}
 		{{#if features.multiattack.items}}
@@ -47,7 +49,7 @@
 			{{/unless}}
 		{{/each}}
 
-		{{! Bonus Actions }}
+	{{! Bonus Actions }}
 		{{#if info.hasBonusActions}}
 			<h2 class="section-header">{{localize "MOBLOKS5E.BonusActions"}}</h2>
 			{{#each features.bonusActions.items as |item iid|}}

--- a/templates/dnd5e/main.hbs
+++ b/templates/dnd5e/main.hbs
@@ -2,6 +2,9 @@
 	{{! Features Menu }}
 		{{#if flags.editing}}
 			{{> "modules/monsterblock/templates/dnd5e/parts/menuItem.hbs" item=menus.features}}
+			{{#unless (or features.features.items.length info.hasActions info.hasBonusActions info.hasLair info.hasLegendaryActions info.hasReactions)}}
+			<p class="menu-hint">{{ localize "MOBLOKS5E.EditButtonHint"}}</p>
+			{{/unless}}
 		{{/if}}
 
 	{{! Spellcasting Features }}


### PR DESCRIPTION
This partially resolves the issue #145 . However, there is one problem I can't seem to solve. 
When there are no items for the NPC, the menu to add items doesn't show up. I'm not entirely sure how to resolve this. I was hoping maybe you could provide some insight.
![image](https://user-images.githubusercontent.com/7407481/154701807-ec555643-b473-4399-8457-0855f1b73e40.png)

![image](https://user-images.githubusercontent.com/7407481/154701912-bc6fbbf0-62ea-4a62-8d9c-364dc34041f6.png)
You can see in this image that the **+** is not present. However, the header, or decoration that it resides on still recedes slightly as though it wants to show it, although it doesn't show up. I'm guessing this is something simple in the html that I am just missing. Or does it have to do with the .css using ::before?