### PR TITLE
Resolves issue #147 At-will spells not appearing in Spellcasting text

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -94,10 +94,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			hasSaveProfs: this.hasSaveProfs(),
 			hasSkills: this.hasSkills(),							
 			hasCastingFeature: Boolean(data.features.casting.items.length),
-			isSpellcaster: this.isSpellcaster(),
-			isInnateSpellcaster: this.isInnateSpellcaster(),
-			isWarlock: this.isWarlock(),
-			hasAtWillSpells: this.hasAtWillSpells(),
 			hasLegendaryActions: Boolean(data.features.legendary.items.length),
 			hasLair: Boolean(data.features.lair.items.length),
 			hasActions: Boolean(data.features.attacks.items.length || data.features.actions.items.length),
@@ -397,24 +393,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	}
 	hasSkills() {
 		return Object.values(this.actor.data?.data?.skills)?.some(skill => skill.value);
-	}
-	isSpellcaster () {	// Regular spellcaster with typical spell slots.
-		return this.actor.data.items.some((item) => {
-			return item.data.level > 0.5 && (
-				item.data.data.preparation?.mode === "prepared" || 
-				item.data.data.preparation?.mode === "always"
-			);
-		});
-	}
-	isInnateSpellcaster() {	// Innate casters have lists of spells that can be cast a certain number of times per day
-		return this.actor.data.items.some((item) => {
-			return item.data.data.preparation?.mode === "innate";
-		});
-	}
-	isWarlock() {
-		return this.actor.data.items.some((item) => {
-			return item.data.data.preparation?.mode === "pact";
-		});
 	}
 	hasAtWillSpells() {	// Some normal casters also have a few spells that they can cast "At will"
 		return this.actor.data.items.some((item) => {

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -401,24 +401,24 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	isSpellcaster () {	// Regular spellcaster with typical spell slots.
 		return this.actor.data.items.some((item) => {
 			return item.data.level > 0.5 && (
-				item.data.preparation?.mode === "prepared" || 
-				item.data.preparation?.mode === "always"
+				item.data.data.preparation?.mode === "prepared" || 
+				item.data.data.preparation?.mode === "always"
 			);
 		});
 	}
 	isInnateSpellcaster() {	// Innate casters have lists of spells that can be cast a certain number of times per day
 		return this.actor.data.items.some((item) => {
-			return item.data.preparation?.mode === "innate";
+			return item.data.data.preparation?.mode === "innate";
 		});
 	}
 	isWarlock() {
 		return this.actor.data.items.some((item) => {
-			return item.data.preparation?.mode === "pact";
+			return item.data.data.preparation?.mode === "pact";
 		});
 	}
 	hasAtWillSpells() {	// Some normal casters also have a few spells that they can cast "At will"
 		return this.actor.data.items.some((item) => {
-			return item.data.preparation?.mode === "atwill";
+			return item.data.data.preparation?.mode === "atwill";
 		});
 	}
 	hasBonusActions() {


### PR DESCRIPTION
This resolves #147.
I've updated `isSpellcaster()`, `isInnateSpellcaster()`, `isWarlock()` and `hasAtWillSpells()` to all reference `item.data.data.preparation.mode` instead of `item.data.preparation.mode`.

The first three methods do not appear to be used anywhere, but I wanted to update the methods anyway as `item.data.preparation` will always be null.