### PR TITLE
Resolves issue #112 Walking speed of zero, and flying (hover) speeds do not display appropriately

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -558,7 +558,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			const speed = data.data.attributes.movement[move];
 			
 			let moveName = move;
-			if (moveName == "fly" && hover) moveName = "hover";
 			const moveNameCaps = moveName.replace(moveName[0], moveName[0].toUpperCase());
 
 			movement.push({
@@ -566,7 +565,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 				fly: move == "fly",
 				showLabel: move != "walk",
 				label: game.i18n.localize(`DND5E.Movement${moveNameCaps}`).toLowerCase(),
-				value: speed > 0 ? speed : "",
+				value: speed > 0 ? speed : move != "walk" ? "" : "0",
 				unit: data.data.attributes.movement.units + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
 				key: `data.attributes.movement.${move}`
 			});

--- a/templates/dnd5e/parts/header/attributes/movement.hbs
+++ b/templates/dnd5e/parts/header/attributes/movement.hbs
@@ -2,39 +2,17 @@
 {{#each movement as |move|~}}
 	<span class="editable-wrapper{{#if (and move.value @index)}} optional-comma{{/if}}">
 		{{~#if (and move.value move.showLabel)}}{{move.label}} {{/if~}}
-		<span class="attr-value" 
-			contenteditable="{{../flags.editing}}"
-			placeholder="&nbsp;{{move.label}}"
-			data-field-key="{{move.key}}"
-			data-dtype="Number">
-			{{~move.value~}}
-		</span>
+		{{#if move.value}}{{move.value}}{{/if~}}
 		{{~#if move.value}} {{move.unit}}{{/if~}}
-		{{~#if (and move.fly ../flags.editing)~}}
-			<span class="hover-only no-break nocaps">
-				(<span class="toggle-button" data-toggle-key="data.attributes.movement.hover"
-					data-toggle-value="{{../data.attributes.movement.hover}}">
-					{{~#if ../data.attributes.movement.hover~}}
-						<i class="fas fa-check"></i>
-					{{~else~}}
-						<i class="far fa-circle"></i>
-					{{~/if}}
-					{{ localize "DND5E.MovementHover" ~}}
-				</span>){{~" "~}}
+		{{~#if (and move.fly ../data.attributes.movement.hover)~}}
+			<span class="no-break nocaps">
+				<span class="paren">(</span>
+					{{~ localize "DND5E.MovementHover" ~}}
+				<span class="paren">)</span>
 			</span>
 		{{~/if~}}
 	</span>
 {{~/each}}
-{{#if flags.editing~}}
-	<div class="hover-only select-field" data-select-key="data.attributes.movement.units" data-selected-value="{{data.attributes.movement.units}}">
-		<label
-			class="{{#if flags.editing}}select-label{{/if}}">{{ lookup config.movementUnits data.attributes.movement.units}}</label>{{~" "~}}
-		<ul class="actor-size select-list">
-			{{#each config.movementUnits as |label unit|}}
-				{{#unless (eq unit ../data.attributes.movement.units)}}
-					<li data-selection-value="{{unit}}">{{label}}</li>
-				{{/unless}}
-			{{~/each~}}
-		</ul>
-	</div>
-{{~/if~}}
+<a class="config-button" data-action="movement" title="{{ localize 'DND5E.MovementConfig' }}">
+	<i class="fas fa-cog"></i>{{~" "~}}
+</a>


### PR DESCRIPTION
This resolves #112 in 3 ways

- Always displays walk speed, even when value is 0
- Hover displayed in parenthesis after fly speed
- Changed the inline entry of values to use the built in menu (cog) the same way Armor Class and Attribute values are modified

![image](https://user-images.githubusercontent.com/7407481/154972222-0d5b81ed-2ba7-4125-8c00-477c88c0bd4f.png)

Notes:

- It would be possible to revert the last bullet point to allow inline entry of values
- Should the cog only be visible when editing? The Armor Class and Attribute value cogs are always visible on hover, even when not editing
- If the last option is kept, I would suggest changing senses to use a cog menu as well for consistency