### PR TITLE
Resolves issue #62 Use Activation Condition for Alternate Target text

### DIFF
--- a/scripts/dnd5e/AttackPreper.js
+++ b/scripts/dnd5e/AttackPreper.js
@@ -120,6 +120,8 @@ export default class AttackPreper extends ItemPreper {
 			? game.i18n.localize("MOBLOKS5E.targetS") // if the value is greater than one it's plural
 			: game.i18n.localize("MOBLOKS5E.target")  // Ortherwise singluar
 
+		if (atkd.activation.condition) return atkd.activation.condition; // if the user has specified a custom targeting condition, use that instead of 1 target / 1 creature
+
 		return game.i18n.format("MOBLOKS5E.AttackTarget", { quantity, type	});
 	}
 


### PR DESCRIPTION
This resolves #62 by using the activation condition field of the weapon when a value is entered instead of the default values of `n target(s)` calculation.

![image](https://user-images.githubusercontent.com/7407481/155038341-6762a422-118e-46ef-8f54-c7e4ac057241.png)