### PR TITLE
Resolves issue #54

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -75,6 +75,18 @@
 				"hint": "By default, show Lair Actions (not normally included in 5e monster stat-blocks)."
 			}
 		},
+		"show-region-actions": {
+			"settings": {
+				"name": "Show Regional Effects",
+				"hint": "By default, show Regional Effects (not normally included in the 5e monster stat-blocks)."
+			}
+		},
+		"show-variant": {
+			"settings": {
+				"name": "Show Variant Information",
+				"hint": "BY default, show variant information (not normally included in the 5e monster stat-blocks)."
+			}
+		},
 		"current-hit-points": {
 			"settings": {
 				"name": "Show Current Hit Points",
@@ -109,6 +121,12 @@
 			"settings": {
 				"name": "Editing Enabled",
 				"hint": "Choose whether or not editing is enabled by default."
+			}
+		},
+		"show-delete": {
+			"settings": {
+				"name": "Show Delete",
+				"hint": "Choose whether or not delete is enabled by default."
 			}
 		},
 		"show-not-prof": {
@@ -164,6 +182,10 @@
 		"HideProfileImage": "Hide profile image",
 		"ShowLair": "Show lair actions",
 		"HideLair": "Hide lair actions",
+		"ShowRegion": "Show regional effects",
+		"HideRegion": "Hide regional effects",
+		"ShowVariant": "Show variant information",
+		"HideVariant": "Hide variant information",
 		"OpenTokenizer": "Open VTTA Tokenizer",
 		"QuickInsert": "Quick Insert",
 
@@ -213,6 +235,7 @@
 		"AddConsumable": "Consumable",
 		
 		"Recharge": "Recharge",
+		"Charged": "Charged",
 		"NCharged": "Not charged",
 		"Costs": "Costs",
 		"ResourceRefresh": "Day",
@@ -233,6 +256,7 @@
 		"SpeedUnitAbbrEnd": ".",
 		"Comma": ",",
 		"Colon": ":",
+		"Or": "or",
 		
 		"Cantrips": "Cantrips",
 		"AtWill": "at will",
@@ -261,10 +285,12 @@
 		"AttackToHit": "{bonus} to hit",
 		"AttackRange": "{reachRange} {range}{sep}{max} {units}.",
 		"AttackTarget": "{quantity} {type}",
+		"ThrownLabel": "Melee or Ranged Weapon Attack",
 		"AttackHitLabel": "Hit:",
 		"AttackDamageTemplate": "{average} ({formula}) {type}",
 		"AttackVersatile": "or {damage} damage if used with two hands",
 		"damage": "damage",
+		"damageVersatile": "damage if used with two hands",
 		
 		"Reactions": "Reactions",
 		"BonusActions": "Bonus Actions",
@@ -297,8 +323,14 @@
 		
 		"LegActionCost": "Costs {number} Actions",
 		"LegendaryText": "The {name} can take {number} legendary actions, choosing from the options below. Only one legendary action option can be used at a time and only at the end of another creature's turn. The {name} regains spent legendary actions at the start of its turn.",
+
+		"MythicActions": "Mythic Actions",
+		"MythicActionText": "If the {name}'s {trait} trait has activated in the last hour, it can use the options below as legendary actions.",
 		
 		"LairActionsHeading": "Lair Actions",
-		"LairText": "On initiative count 20 (losing all initiative ties), the {name} takes a lair action to cause one of the following effects; the {name} can't use the same effect two rounds in a row:"
+		"LairText": "On initiative count 20 (losing all initiative ties), the {name} takes a lair action to cause one of the following effects; the {name} can't use the same effect two rounds in a row:",
+
+		"RegionHeading" : "Regional Effects",
+		"VariantHeading": "Variant Features"
 	}
 }

--- a/module.json
+++ b/module.json
@@ -2,20 +2,12 @@
 	"name": "monsterblock",
 	"title": "Monster Blocks",
 	"description": "An NPC sheet designed to emulate standard 5e monster stat blocks as faithfully as possible.",
-	"author": "zeel",
-	"authors": [
-		{
-			"name": "zeel",
-			"email": "zeel02@gmail.com",
-			"url": "https://github.com/zeel01",
-			"discord": "zeel#4200"
-		}
-	],
-	"version": "3.2.4",
+	"author": "Zeel, Tielc",
+	"version": "3.2.5",
 	"minimumCoreVersion": "0.8.8",
 	"compatibleCoreVersion": "9",
 	"system": ["dnd5e"],
-	"minimumSystemVersion": "1.5.0",
+	"minimumSystemVersion": "1.5.7",
 	"esmodules": [
 		"monsterblock.js"
 	],
@@ -51,13 +43,10 @@
 			"manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/mathjs-lib/master/module.json"
 		}
 	],
-	"manifest": "https://github.com/zeel01/MonsterBlocks/releases/latest/download/module.json",
-	"url": "https://github.com/zeel01/MonsterBlocks",
-	"download": "https://github.com/zeel01/MonsterBlocks/releases/latest/download/monsterblock.zip",
-	"readme": "https://github.com/zeel01/MonsterBlocks/blob/master/readme.md",
-	"bugs": "https://github.com/zeel01/MonsterBlocks/issues",
+	"url": "https://github.com/jeremyregnerus/MonsterBlocks",
+	"readme": "https://github.com/jeremyregnerus/MonsterBlocks/blob/master/readme.md",
+	"bugs": "https://github.com/jeremyregnerus/MonsterBlocks/issues",
 	"allowBugReporter": true,
-	"changelog": "https://github.com/zeel01/MonsterBlocks/releases",
 	"media": [
 		{
 			"type": "cover",

--- a/monsterblock.css
+++ b/monsterblock.css
@@ -239,6 +239,9 @@
 	height: 1em;
 	padding: 0;
 }
+.monsterblock .item-attackRoll:hover,
+.monsterblock .item-damageRoll:hover,
+.monsterblock .hpRoll:hover,
 .monsterblock .ability:hover, 
 .monsterblock .saving-throw:hover, 
 .monsterblock .skill:hover, 
@@ -538,12 +541,6 @@
 	border: none;
 	margin-right: 0;
 }
-.monsterblock.compact-layout .profile-image:hover,
-.monsterblock .profile-image:hover {
-	width: calc(var(--column-width) * 0.7);
-	height: calc(var(--column-width) * 0.7);
-	z-index: 75;
-}
 
 .monsterblock .ac-type {
 	text-transform: lowercase;
@@ -660,9 +657,6 @@ li:nth-last-of-type(2):after {
 .monsterblock .at-will-spells li:last-of-type:after {
 	content: '';
 }
-.monsterblock .spell-name {
-	font-style: italic;
-}
 .monsterblock .monster-saves .ability {
 	display: inline;
 }
@@ -682,6 +676,7 @@ li:nth-last-of-type(2):after {
 	margin-top: 1em;
 	/* display: inline-flex; */
 }
+.monsterblock .spell-name,
 .monsterblock .item-name,
 .monsterblock .name-extension {
 	font-weight: bold;
@@ -690,27 +685,24 @@ li:nth-last-of-type(2):after {
 .monsterblock .spell .name-extension {
 	font-weight: initial;
 }
-.monsterblock .legendary-actions .feature-description {
-	padding-left: 2ch;
-	text-indent: -2ch;
+.monsterblock .special-actions .feature-description {
+	padding-left: 1.5ch;
+	text-indent: -1.5ch;
 }
-.monsterblock .legendary-actions .feature-description .fas {
+.monsterblock .special-actions .feature-description .fas {
 	text-indent: 0ch;
 }
-.monsterblock .legendary-actions .item-name,
-.monsterblock .legendary-actions .name-extension {
+.monsterblock .item-attackRoll,
+.monsterblock .item-damageRoll,
+.monsterblock .special-actions .item-name,
+.monsterblock .special-actions .name-extension {
 	font-weight: bold;
 	font-style: normal;
 }
-.monsterblock .legendary-actions,
-.monsterblock .lair-actions {
+.monsterblock .special-actions {
 	margin: 0;
 }
-.monsterblock .legendary-description {
-	margin-top: 1em;
-	margin-bottom: 1em;
-}
-.monsterblock .lair-description {
+.monsterblock .special-description {
 	margin-top: 1em;
 }
 
@@ -820,7 +812,7 @@ li:nth-last-of-type(2):after {
 .monsterblock .editor {
 	height: 100%;
 }
-.monsterblock .bio-box h2 {
+.monsterblock .bio-box .section-header h2 {
 	margin-top: 2.5em;
 }
 .monsterblock .biography {
@@ -1108,3 +1100,6 @@ li:nth-last-of-type(2):after {
 .monsterblock .flavor-text > p {
 	padding: 0 1ch;
 }
+.monsterblock .warn {
+	color: darkred;
+} 

--- a/scripts/Flags.js
+++ b/scripts/Flags.js
@@ -20,7 +20,7 @@ export default class Flags {
 	static get flagDefaults() {
 		return {
 			"inline-secrets"    : { type: Boolean, default: false    , hidden: false },
-			"hidden-secrets"    : { type: Boolean, default: false    , hidden: false },
+			"hidden-secrets"    : { type: Boolean, default: true     , hidden: false },
 			"hide-profile-image": { type: Boolean, default: false    , hidden: false },
 			"theme-choice"      : { type: String , default: "default", hidden: true, setting: "default-theme" },
 			"custom-theme-class": { type: String , default: ""       , hidden: false },
@@ -28,7 +28,7 @@ export default class Flags {
 			"compact-window"    : { type: Boolean, default: false    , hidden: false },
 			"compact-feats"     : { type: Boolean, default: false    , hidden: false },
 			"compact-layout"    : { type: Boolean, default: false    , hidden: false },
-			"show-delete"       : { type: Boolean, default: false    , hidden: true  },
+			"show-delete"       : { type: Boolean, default: true     , hidden: false },
 			"font-size"         : { type: Number , default: 14       , hidden: false },
 			"scale"             : { type: Number , default: 1        , hidden: true  }
 		}

--- a/scripts/dnd5e/ActionPreper.js
+++ b/scripts/dnd5e/ActionPreper.js
@@ -11,9 +11,15 @@ export default class ActionPreper extends ItemPreper {
 	 * @typedef Is
 	 * @property {boolean} specialAction - Whether or not is any of the below
 	 * @property {boolean} multiattack   - Whether or not this is the multiattack action
+	 * @property {boolean} mythic        - Whether or not this is a mythic action
+	 * @property {boolean} mythicTrait   - Whether or not this is the mythic trait which triggers the mythic actions
 	 * @property {boolean} legendary     - Whether or not this is a legendary action
 	 * @property {boolean} lair          - Whether or not this is a lair action
+	 * @property {boolean} region        - Whether or not this is a regional effect
+	 * @property {boolean} regionStart   - Whether or not this is the opening text of regional effects
+	 * @property {boolean} regionalEnd   - Whether or not this is the closing text of regional effects
 	 * @property {boolean} legResist     - Whether or not this is the legendary resistance feature
+	 * @property {boolean} bonusAction   - Whether or not this is a bonus action
 	 * @property {boolean} reaction      - Whether or not this is a reaction
 	 *//**
 	 *
@@ -28,10 +34,16 @@ export default class ActionPreper extends ItemPreper {
 		/** @type {Is} */
 		const is = { 
 			multiAttack:  MonsterBlock5e.isMultiAttack(data),
+			mythic:       MonsterBlock5e.isMythicAction(data),
+			mythicTrait:  MonsterBlock5e.isMythicTrait(data),
 			legendary:    MonsterBlock5e.isLegendaryAction(data),
 			lair:         MonsterBlock5e.isLairAction(data),
+			region:       MonsterBlock5e.isRegionEffect(data),
+			regionStart:  MonsterBlock5e.isRegionStart(data),
+			regionEnd:    MonsterBlock5e.isRegionEnd(data),
+			variant:      MonsterBlock5e.isVariant(data),
 			legResist:    MonsterBlock5e.isLegendaryResistance(data),
-			bonusAction:  MonsterBlock5e.isBonusAction(data),
+			bonus:        MonsterBlock5e.isBonusAction(data),
 			reaction:     MonsterBlock5e.isReaction(data)
 		};
 		is.specialAction = this.isSpecialAction(is);

--- a/scripts/dnd5e/Flags5e.js
+++ b/scripts/dnd5e/Flags5e.js
@@ -15,6 +15,8 @@ export default class Flags5e extends Flags {
 			"current-hit-points" : { type: Boolean, default: true , hidden: false },
 			"maximum-hit-points" : { type: Boolean, default: true , hidden: false },
 			"show-lair-actions"  : { type: Boolean, default: false, hidden: false },
+			"show-region-actions": { type: Boolean, default: false, hidden: false },
+			"show-variant"       : { type: Boolean, default: false, hidden: false },
 			"show-not-prof"      : { type: Boolean, default: false, hidden: false },
 			"show-resources"     : { type: Boolean, default: true , hidden: false },
 			"show-skill-save"    : { type: Boolean, default: true , hidden: false },

--- a/scripts/dnd5e/ItemPrep.js
+++ b/scripts/dnd5e/ItemPrep.js
@@ -39,17 +39,24 @@ export default class ItemPrep {
 	
 	/** @type {Object.<string, Feature>} A set of item classifications by type */
 	features = {
-		legResist:	  { prep: ItemPreper,    filter: MonsterBlock5e.isLegendaryResistance,         label: game.i18n.localize("MOBLOKS5E.LegendaryResistance"), items: [], dataset: {type: "feat"}   },
-		legendary:	  { prep: ActionPreper,  filter: MonsterBlock5e.isLegendaryAction,             label: game.i18n.localize("DND5E.LegAct"),                  items: [], dataset: {type: "feat"}   },
-		lair:		  { prep: ActionPreper,  filter: MonsterBlock5e.isLairAction,                  label: game.i18n.localize("MOBLOKS5E.LairActionsHeading"),  items: [], dataset: {type: "feat"}   },
-		multiattack:  { prep: ActionPreper,  filter: MonsterBlock5e.isMultiAttack,                 label: game.i18n.localize("MOBLOKS5E.Multiattack"),         items: [], dataset: {type: "feat"}   },
-		casting:	  { prep: CastingPreper, filter: CastingPreper.isCasting.bind(CastingPreper),  label: game.i18n.localize("DND5E.Features"),                items: [], dataset: {type: "feat"}   },
-		reaction:	  { prep: ActionPreper,  filter: MonsterBlock5e.isReaction,                    label: game.i18n.localize("MOBLOKS5E.Reactions"),           items: [], dataset: {type: "feat"}   },
-		bonusActions: { prep: ActionPreper,  filter: MonsterBlock5e.isBonusAction,                 label: game.i18n.localize("MOBLOKS5E.BonusActions"),        items: [], dataset: {type: "feat"}   },
-		attacks:	  { prep: AttackPreper,  filter: item => item.type === "weapon",               label: game.i18n.localize("DND5E.AttackPl"),                items: [], dataset: {type: "weapon"} },
-		actions:	  { prep: ActionPreper,  filter: MonsterBlock5e.isAction,                      label: game.i18n.localize("DND5E.ActionPl"),                items: [], dataset: {type: "feat"}   },
-		features:	  { prep: ItemPreper,    filter: item => item.type === "feat",                 label: game.i18n.localize("DND5E.Features"),                items: [], dataset: {type: "feat"}   },
-		equipment:	  { prep: ItemPreper,    filter: () => true,                                   label: game.i18n.localize("DND5E.Inventory"),               items: [], dataset: {type: "loot"}   }
+		legResist:		{ prep: ItemPreper,		filter: MonsterBlock5e.isLegendaryResistance,			items: [], dataset: {type: "feat"}		},
+		legendary:		{ prep: ActionPreper,	filter: MonsterBlock5e.isLegendaryAction,				items: [], dataset: {type: "feat"}		},
+		mythic:			{ prep: ActionPreper,	filter: MonsterBlock5e.isMythicAction,					items: [], dataset: {type: "feat"}		},
+		mythicTrait:	{ prep: ItemPreper,		filter: MonsterBlock5e.isMythicTrait,					items: [], dataset: {type: "feat"}		},
+		lair:			{ prep: ActionPreper,	filter: MonsterBlock5e.isLairAction,					items: [], dataset: {type: "feat"}		},
+		region:			{ prep: ActionPreper,	filter: MonsterBlock5e.isRegionEffect,					items: [], dataset: {type: "feat"}		},
+		regionStart:	{ prep: ActionPreper,	filter: MonsterBlock5e.isRegionStart,					items: [], dataset: {type: "feat"}		},
+		regionEnd:		{ prep: ActionPreper,	filter: MonsterBlock5e.isRegionEnd,						items: [], dataset: {type: "feat"}		},
+		variant:		{ prep: ActionPreper,	filter: MonsterBlock5e.isVariant,						items: [], dataset:	{type: "feat"}		},
+		multiattack:	{ prep: ActionPreper,	filter: MonsterBlock5e.isMultiAttack,					items: [], dataset: {type: "feat"}		},
+		casting:		{ prep: CastingPreper,	filter: CastingPreper.isCasting.bind(CastingPreper),	items: [], dataset: {type: "feat"}		},
+		reaction:		{ prep: ActionPreper,	filter: MonsterBlock5e.isReaction,						items: [], dataset: {type: "feat"}		},
+		bonus:			{ prep: ActionPreper,	filter: MonsterBlock5e.isBonusAction,					items: [], dataset: {type: "feat"}		},
+		attacks:		{ prep: AttackPreper,	filter: item => item.type === "weapon",					items: [], dataset: {type: "weapon"}	},
+		actions:		{ prep: ActionPreper,	filter: MonsterBlock5e.isAction,						items: [], dataset: {type: "feat"}		},
+		features:		{ prep: ItemPreper,		filter: item => item.type === "feat",					items: [], dataset: {type: "feat"}		},
+		armor:			{ prep: ItemPreper,		filter: MonsterBlock5e.isArmor,							items: [], dataset: {type: "equipment"}	},
+		equipment:		{ prep: ItemPreper,		filter: () => true,										items: [], dataset: {type: "loot"}		}
 	};
 	
 	/**

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1209,6 +1209,9 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
+		},
+		"moblok-equals": (val, compare) => {
+			return val === compare;
 		}
 	};
 

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -99,10 +99,14 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			isWarlock: this.isWarlock(),
 			hasAtWillSpells: this.hasAtWillSpells(),
 			hasLegendaryActions: Boolean(data.features.legendary.items.length),
+			hasMythicActions: Boolean(data.features.mythic.items.length || data.features.mythicTrait.items.length),
 			hasLair: Boolean(data.features.lair.items.length),
+			hasRegion: Boolean(data.features.region.items.length || data.features.regionStart.items.length || data.features.regionEnd.items.length),
+			hasVariant: Boolean(data.features.variant.items.length),
 			hasActions: Boolean(data.features.attacks.items.length || data.features.actions.items.length),
-			hasBonusActions: Boolean(data.features.bonusActions.items.length),
+			hasBonusActions: Boolean(data.features.bonus.items.length),
 			hasReactions: Boolean(data.features.reaction.items.length),
+			hasArmor: Boolean(data.features.armor.items.length),
 			hasLoot: Boolean(data.features.equipment.items.length),
 			vttatokenizer: Boolean(window.Tokenizer)
 		}
@@ -401,24 +405,24 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	isSpellcaster () {	// Regular spellcaster with typical spell slots.
 		return this.actor.data.items.some((item) => {
 			return item.data.level > 0.5 && (
-				item.data.preparation?.mode === "prepared" || 
-				item.data.preparation?.mode === "always"
+				item.data.data.preparation?.mode === "prepared" || 
+				item.data.data.preparation?.mode === "always"
 			);
 		});
 	}
 	isInnateSpellcaster() {	// Innate casters have lists of spells that can be cast a certain number of times per day
 		return this.actor.data.items.some((item) => {
-			return item.data.preparation?.mode === "innate";
+			return item.data.data.preparation?.mode === "innate";
 		});
 	}
 	isWarlock() {
 		return this.actor.data.items.some((item) => {
-			return item.data.preparation?.mode === "pact";
+			return item.data.data.preparation?.mode === "pact";
 		});
 	}
 	hasAtWillSpells() {	// Some normal casters also have a few spells that they can cast "At will"
 		return this.actor.data.items.some((item) => {
-			return item.data.preparation?.mode === "atwill";
+			return item.data.data.preparation?.mode === "atwill";
 		});
 	}
 	hasBonusActions() {
@@ -439,6 +443,21 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	hasLegendaryActions() {
 		return this.actor.data.items.some((item) => {
 			return this.constructor.isLegendaryAction(item)
+		});
+	}
+	hasMythicActions() {
+		return this.actor.items.some((item) => {
+			this.constructor.isMythicAction(item) || this.constructor.isMythicTrait(item);
+		});
+	}
+	hasRegion() {
+		return this.actor.data.items.some((item) => {
+			return this.constructor.isRegionEffect(item) || this.constructor.isRegionStart(item) || this.constructor.isRegionEnd(item);
+		});
+	}
+	hasVariant() {
+		return this.actor.data.items.some((item) => {
+			return this.constructor.isVariant(item);
 		});
 	}
 	async openTokenizer() {
@@ -558,7 +577,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			const speed = data.data.attributes.movement[move];
 			
 			let moveName = move;
-			if (moveName == "fly" && hover) moveName = "hover";
 			const moveNameCaps = moveName.replace(moveName[0], moveName[0].toUpperCase());
 
 			movement.push({
@@ -566,7 +584,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 				fly: move == "fly",
 				showLabel: move != "walk",
 				label: game.i18n.localize(`DND5E.Movement${moveNameCaps}`).toLowerCase(),
-				value: speed > 0 ? speed : "",
+				value: speed > 0 ? speed : move != "walk" ? "" : "0",
 				unit: data.data.attributes.movement.units + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
 				key: `data.attributes.movement.${move}`
 			});
@@ -655,13 +673,15 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			"maximum-hit-points": game.settings.get("monsterblock", "maximum-hit-points"),
 			"hide-profile-image": game.settings.get("monsterblock", "hide-profile-image"),
 			"show-lair-actions": game.settings.get("monsterblock", "show-lair-actions"),
+			"show-region-actions": game.settings.get("monsterblock", "show-region-actions"),
+			"show-variant": game.settings.get("monsterblock", "show-variant"),
 			"theme-choice": game.settings.get("monsterblock", "default-theme"),
 			"custom-theme-class": game.settings.get("monsterblock", "custom-theme-class"),
 			"editing": game.settings.get("monsterblock", "editing"),
+			"show-delete": game.settings.get("monsterblock", "show-delete"),
 			"show-not-prof": game.settings.get("monsterblock", "show-not-prof"),
 			"show-resources": game.settings.get("monsterblock", "show-resources"),
 			"show-skill-save": game.settings.get("monsterblock", "show-skill-save"),
-			"show-delete": false,
 			"show-bio": false,
 			"scale": 1.0,
 			"compact-window": game.settings.get("monsterblock", "compact-window"),
@@ -787,6 +807,25 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			}
 			else return item.roll(); // Conveniently, items have all this logic built in already.
 		});
+
+		// uses the built in attack roll from the item
+		html.find(".item-attackRoll").click(async (event) => {
+			let id = event.currentTarget.dataset.itemId;
+			const item = this.actor.items.get(id);
+
+			item.rollAttack({event});
+		});
+
+		// uses the built in damage roll from the item
+		html.find(".item-damageRoll").click(async (event) => {
+			let id = event.currentTarget.dataset.itemId;
+			let versatile = event.currentTarget.dataset.versatile;
+			const item = this.actor.items.get(id);
+
+			console.log(`Versatile = ${versatile}`);
+
+			item.rollDamage({event, versatile});
+		})
 		
 		// Item editing handlers. Allows right clicking on the description of any item (features, action, etc.) to open its own sheet to edit.
 		html.find(".item").contextmenu(this.openItemEditor.bind(this));
@@ -1163,8 +1202,32 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		return item.data?.activation?.type === "legendary";
 	}
 	
+	static isMythicAction(item) {
+		return item.data?.activation?.type === "mythic";
+	}
+
+	static isMythicTrait(item) {
+		return item.data?.requirements?.toLowerCase() === "mythictrait";
+	}
+
 	static isLairAction(item) {
 		return item.data?.activation?.type === "lair";
+	}
+
+	static isRegionEffect(item) {
+		return item.data?.requirements?.toLowerCase() === "region";
+	}
+
+	static isRegionStart(item) {
+		return item.data?.requirements?.toLowerCase() === "regionstart";
+	}
+
+	static isRegionEnd(item) {
+		return item.data?.requirements?.toLowerCase() === "regionend";
+	}
+
+	static isVariant(item) {
+		return item.data?.requirements?.toLowerCase() === "variant";
 	}
 
 	static isAction(item) {
@@ -1179,6 +1242,10 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		return item.data?.activation?.type === "reaction";
 	}
 		
+	static isArmor(item) {
+		const type = item.data?.armor?.type;
+		return type === "light" || type === "medium" || type === "heavy" || type === "natural" || type === "shield";
+	}
 
 	static getItemAbility(item, actor, master) {
 		return master.object.items.get(item._id).abilityMod;
@@ -1212,6 +1279,27 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-equals": (val, compare) => {
 			return val === compare;
+    },
+		"moblok-toLowerCase": (str) => { // Formats any text to lowercase.
+			return str ? str.toLowerCase() : "";
+		},
+		"moblok-isEquipment": (item) => {
+			return [`loot`, `equipment`, `consumable`, `backpack`].includes(item?.type);
+		},
+		"moblok-isArmor": (item) => {
+			return item.data.armor.type === "light" || item.data.armor.type === "medium" || item.data.armor.type === "heavy" || item.data.armor.type === "natural" || item.data.armor.type === "shield";
+		},
+		"moblok-isAsterisk": (str) => {
+			return str === "*" || str === "•" || str === "—";
+		},
+		"moblok-isUnderscore": (str) => {
+			return str.startsWith(`_`);
+		},
+		"moblok-moreThanOne": (item) => {
+			return item.data?.quantity > 1;
+		},
+		"moblok-greaterThan": (x, y) => {
+			return x > y;
 		}
 	};
 
@@ -1244,10 +1332,14 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			"modules/monsterblock/templates/dnd5e/parts/main/attack.hbs",
 			"modules/monsterblock/templates/dnd5e/parts/main/legendaryActs.hbs",
 			"modules/monsterblock/templates/dnd5e/parts/main/lairActs.hbs",
+			"modules/monsterblock/templates/dnd5e/parts/main/regionActs.hbs",
+			"modules/monsterblock/templates/dnd5e/parts/main/regionCap.hbs",
+			"modules/monsterblock/templates/dnd5e/parts/main/variantInfo.hbs",
 
 			"modules/monsterblock/templates/dnd5e/parts/menuItem.hbs",
 			"modules/monsterblock/templates/dnd5e/parts/resource.hbs",
 			"modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs",
+			"modules/monsterblock/templates/dnd5e/parts/itemList.hbs",
 			"modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs"
 
 		]);

--- a/templates/dnd5e/main.hbs
+++ b/templates/dnd5e/main.hbs
@@ -55,8 +55,8 @@
 	{{! Bonus Actions }}
 		{{#if info.hasBonusActions}}
 			<h2 class="section-header">{{localize "MOBLOKS5E.BonusActions"}}</h2>
-			{{#each features.bonusActions.items as |item iid|}}
-				{{#if item.is.bonusAction}}
+			{{#each features.bonus.items as |item iid|}}
+				{{#if item.is.bonus}}
 					{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor flags=@root.flags}}
 				{{/if}}
 			{{/each}}
@@ -75,12 +75,13 @@
 		{{#if info.hasLegendaryActions}}
 			{{> "modules/monsterblock/templates/dnd5e/parts/main/legendaryActs.hbs"}}
 		{{/if}}
-	
-	{{! Loot Items }}
-		{{#if info.hasLoot}}
-			<h2 class="section-header">{{localize "DND5E.Inventory"}}</h2>
-			{{#each features.equipment.items as |item iid|}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor flags=@root.flags}}
+
+	{{! Mythic Actions }}
+		{{#if info.hasMythicActions}}
+			<h2 class="section-header">{{localize "MOBLOKS5E.MythicActions"}}</h2>
+			<p class="special-description">{{ localize "MOBLOKS5E.MythicActionText" name=actor.name trait=features.mythicTrait.items.[0].name}}</p>
+			{{#each features.mythic.items as |item iid|}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor flags=@root.flags specialaction=true}}
 			{{/each}}
 		{{/if}}
 
@@ -89,5 +90,35 @@
 			{{#if flags.show-lair-actions}}
 				{{> "modules/monsterblock/templates/dnd5e/parts/main/lairActs.hbs"}}
 			{{/if}}
+		{{/if}}
+
+	{{! Regional Effects }}
+		{{#if (and flags.show-region-actions info.hasRegion)}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/main/regionActs.hbs"}}
+		{{/if}}
+
+	{{! Variant Features}}
+		{{#if (and flags.show-variant info.hasVariant)}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/main/variantInfo.hbs" actor=@root.actor flags=@root.flags}}
+		{{/if}}
+
+	{{! Loot Items }}
+		{{#if info.hasLoot}}
+			<h2 class="section-header">{{localize "DND5E.Inventory"}}</h2>
+			<section class="item monster-feature{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}"></section>
+			{{#each features.equipment.items as |item iid|}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/itemList.hbs" item=item actor=@root.actor flags=@root.flags}}
+			{{/each}}
+			</section>
+		{{/if}}
+
+	{{! Armor Items }}
+		{{#if (and flags.editing info.hasArmor)}}
+			<h2 class="section-header">{{localize "DND5E.Armor"}}</h2>
+			<section class="item monster-feature{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}"></section>
+			{{#each features.armor.items as |item iid|}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/itemList.hbs" item=item actor=@root.actor flags=@root.flags}}
+			{{/each}}
+			</section>
 		{{/if}}
 </main>

--- a/templates/dnd5e/parts/featureBlock.hbs
+++ b/templates/dnd5e/parts/featureBlock.hbs
@@ -1,17 +1,17 @@
-<section class="item monster-feature{{#if legendaryactions}} legendary-actions{{/if}}{{#if lairactions}} lair-actions{{/if}}{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
+<section class="item monster-feature{{#if specialaction}} special-actions{{/if}}{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
 	<div class="feature-description inline-children">
 		{{#if flags.show-delete}}
 			<a class="delete-item" data-item-id="{{item._id}}">
 				<i class="fa fa-trash"></i>
 			</a>
 		{{/if}}
-		{{#unless lairactions}}
+		{{#unless (moblok-isUnderscore item.name)}}
 			<span class="item-name" data-item-id="{{item._id}}">
 				{{~item.name~}} 
 			</span>
 			
 			{{~#if item.data.recharge.value~}}
-				<span class="name-extension"
+				<span class="name-extension{{#unless item.data.recharge.charged}} warn{{/unless}}"
 					data-item-id="{{item._id}}"
 					data-roll-flavor="{{item.name}} ({{ localize 'MOBLOKS5E.Recharge' }} {{item.data.recharge.value}}-6): " 
 					data-roll-formula="1d6" 
@@ -19,22 +19,26 @@
 					data-roll-success="{{ localize 'DND5E.Charged' }}" 
 					data-roll-failure="{{ localize 'MOBLOKS5E.NCharged' }}"
 					data-roll-handler="setCharged">
-					({{ localize 'MOBLOKS5E.Recharge' }} {{item.data.recharge.value}}-6){{~" "~}}
+					({{#if item.data.recharge.charged }}{{ localize "MOBLOKS5E.Charged" }}{{else}}{{ localize "MOBLOKS5E.Recharge" }}{{/if}} {{item.data.recharge.value}}-6){{~" "~}}
 				</span>
 			{{~/if~}}
-			{{~#if (and item.is.legendary (gt item.data.activation.cost 1))~}}
-				<span class="name-extension">
-					({{ localize "MOBLOKS5E.LegActionCost" number=item.data.activation.cost}}){{~" "~}}
-				</span>
-			{{~/if~}}
-			{{~#unless legendaryactions~}}
+			{{~#if (or item.is.legendary item.is.mythic)~}}
+				{{~#if (gt item.data.activation.cost 1)~}}
+					<span class="name-extension">
+						({{ localize "MOBLOKS5E.LegActionCost" number=item.data.activation.cost}}){{~" "~}}
+					</span>
+				{{~/if~}}
+			{{~else~}}
 				{{~#if item.hasresource~}}
 					{{> "modules/monsterblock/templates/dnd5e/parts/resource.hbs" resource=item.resource}}
 				{{~/if~}}
-			{{~/unless~}}{{ localize "MOBLOKS5E.NameDescriptionSep" }}
+			{{~/if~}}
+			{{~#unless (moblok-isAsterisk item.name)~}}{{ localize "MOBLOKS5E.NameDescriptionSep" }}{{~/unless}}
 		{{~else~}}
 			<span class="item-name" data-item-id="{{item._id}}"></span>
 		{{~/unless}}
-		<span class="description">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</span>
+		{{~#unless (moblok-isEquipment item)}}
+			<span class="description">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</span>
+		{{~/unless}}
 	</div>
 </section>

--- a/templates/dnd5e/parts/header/attributes/armorclass.hbs
+++ b/templates/dnd5e/parts/header/attributes/armorclass.hbs
@@ -2,17 +2,22 @@
 <span class="attr-value">
 	<span class="ac-value">{{data.attributes.ac.value}}</span>
 	{{#unless (eq data.attributes.ac.calc "flat")}}
-		<span class="paren">(</span>{{~" "~}}
-		<span class="ac-type">
-			{{~#if (eq data.attributes.ac.calc "custom")~}}
-			{{data.attributes.ac.formula}}
-			{{~else~}}
-			{{labels.armorType}}
-			{{~/if~}}
-		</span>{{~" "~}}
-		<span class="paren">)</span>
+		{{#unless (eq labels.armorType "Unarmored")}}
+			(<span class="ac-type">
+				{{~#if (eq data.attributes.ac.calc "custom")~}}
+				{{data.attributes.ac.formula}}
+				{{~else~}}
+				{{labels.armorType}}
+				{{~/if~}}
+			</span>)
+		{{/unless}}
 	{{/unless}}
 </span>
+<span class="attr-value"
+	data-field-key="data.attributes.ac.text"
+	data-dtype="String"
+	placeholder=""
+	contenteditable="{{flags.editing}}">{{data.attributes.ac.text}}</span>
 <a class="config-button" data-action="armor" title="{{ localize 'DND5E.ArmorConfig' }}">
 	<i class="fas fa-cog"></i>{{~" "~}}
 </a>{{~" "~}}

--- a/templates/dnd5e/parts/header/attributes/damage.hbs
+++ b/templates/dnd5e/parts/header/attributes/damage.hbs
@@ -3,10 +3,15 @@
 		<span class="attribute-wrapper">
 			<h4 class="attribute-name">{{localize label}}</h4>
 			<ul class="traits-list inline-list no-caps">
-				{{#each damage as |v k|}}
-					<li class="trait-value">{{v}}</li>
-				{{/each}}
+				{{~#each damage as |v k|~}}
+					{{~#unless (moblok-equals k "physical")~}}
+						<li class="trait-value">{{v}}</li>
+					{{~/unless~}}
+				{{~/each~}}
 			</ul>
+			{{~#each damage as |v k|~}}
+				{{~#if (moblok-equals k "physical")~}}<span>{{~#unless (moblok-equals @index 0)~}}; {{/unless}}{{v}}</span>{{~/if~}}
+			{{~/each~}}
 		</span>
 	</li>
 {{/if}}

--- a/templates/dnd5e/parts/header/attributes/damage.hbs
+++ b/templates/dnd5e/parts/header/attributes/damage.hbs
@@ -10,7 +10,12 @@
 				{{~/each~}}
 			</ul>
 			{{~#each damage as |v k|~}}
-				{{~#if (moblok-equals k "physical")~}}<span>{{~#unless (moblok-equals @index 0)~}}; {{/unless}}{{v}}</span>{{~/if~}}
+				{{~#if (moblok-equals k "physical")~}}
+					<span>
+						{{~#unless (moblok-equals @index 0)~}}; {{/unless}}
+						{{v}}
+					</span>
+				{{~/if~}}
 			{{~/each~}}
 		</span>
 	</li>

--- a/templates/dnd5e/parts/header/attributes/hitpoints.hbs
+++ b/templates/dnd5e/parts/header/attributes/hitpoints.hbs
@@ -43,8 +43,9 @@
 	placeholder="(1d6)"
 	data-field-key="data.attributes.hp.formula"
 	data-dtype="Roll"
-	class="attr-value"
-	contenteditable="{{flags.editing}}">
+	class="attr-value{{#unless flags.editing}} trigger hpRoll{{/unless}}"
+	contenteditable="{{flags.editing}}"
+	data-control="_onRollHPFormula">
 		{{~data.attributes.hp.formula~}}
 </span>{{~" "~}}
 {{#if data.attributes.hp.formula}}<span class="paren">)</span>{{~/if~}}

--- a/templates/dnd5e/parts/header/attributes/movement.hbs
+++ b/templates/dnd5e/parts/header/attributes/movement.hbs
@@ -2,39 +2,17 @@
 {{#each movement as |move|~}}
 	<span class="editable-wrapper{{#if (and move.value @index)}} optional-comma{{/if}}">
 		{{~#if (and move.value move.showLabel)}}{{move.label}} {{/if~}}
-		<span class="attr-value" 
-			contenteditable="{{../flags.editing}}"
-			placeholder="&nbsp;{{move.label}}"
-			data-field-key="{{move.key}}"
-			data-dtype="Number">
-			{{~move.value~}}
-		</span>
+		{{#if move.value}}{{move.value}}{{/if~}}
 		{{~#if move.value}} {{move.unit}}{{/if~}}
-		{{~#if (and move.fly ../flags.editing)~}}
-			<span class="hover-only no-break nocaps">
-				(<span class="toggle-button" data-toggle-key="data.attributes.movement.hover"
-					data-toggle-value="{{../data.attributes.movement.hover}}">
-					{{~#if ../data.attributes.movement.hover~}}
-						<i class="fas fa-check"></i>
-					{{~else~}}
-						<i class="far fa-circle"></i>
-					{{~/if}}
-					{{ localize "DND5E.MovementHover" ~}}
-				</span>){{~" "~}}
+		{{~#if (and move.fly ../data.attributes.movement.hover)~}}
+			<span class="no-break nocaps">
+				<span class="paren">(</span>
+					{{~ localize "DND5E.MovementHover" ~}}
+				<span class="paren">)</span>
 			</span>
 		{{~/if~}}
 	</span>
 {{~/each}}
-{{#if flags.editing~}}
-	<div class="hover-only select-field" data-select-key="data.attributes.movement.units" data-selected-value="{{data.attributes.movement.units}}">
-		<label
-			class="{{#if flags.editing}}select-label{{/if}}">{{ lookup config.movementUnits data.attributes.movement.units}}</label>{{~" "~}}
-		<ul class="actor-size select-list">
-			{{#each config.movementUnits as |label unit|}}
-				{{#unless (eq unit ../data.attributes.movement.units)}}
-					<li data-selection-value="{{unit}}">{{label}}</li>
-				{{/unless}}
-			{{~/each~}}
-		</ul>
-	</div>
-{{~/if~}}
+<a class="config-button" data-action="movement" title="{{ localize 'DND5E.MovementConfig' }}">
+	<i class="fas fa-cog"></i>{{~" "~}}
+</a>

--- a/templates/dnd5e/parts/itemList.hbs
+++ b/templates/dnd5e/parts/itemList.hbs
@@ -1,0 +1,11 @@
+<span class="item{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
+	{{#if flags.show-delete}}
+		<a class="delete-item" data-item-id="{{item._id}}">
+			<i class="fa fa-trash"></i>
+		</a>
+	{{/if}}
+	<span class="item-name" data-item-id="{{item._id}}">
+		{{#if (moblok-greaterThan item.data.quantity 1) }}({{item.data.quantity}}) {{/if}}{{~item.name~}}
+	</span>
+	{{~#unless @last}}<span>, </span>{{~/unless~}}
+</span>

--- a/templates/dnd5e/parts/main/attack.hbs
+++ b/templates/dnd5e/parts/main/attack.hbs
@@ -12,14 +12,11 @@
 		{{ localize "MOBLOKS5E.NameDescriptionSep" }}
 		{{#if @root.flags.attack-descriptions}}
 		<span class="generated-text">			
-			<span class="attack-bonus" 
-				data-roll-flavor="{{ localize "DND5E.Attack" }}: {{item.name}}" 
-				data-roll-formula="1d20 + {{item.tohit}}">
 				<span class="attack-type">
 					{{~item.description.attackType~}}
 					{{ localize "MOBLOKS5E.Colon" }}
 				</span>
-				{{item.description.tohit~}}
+				<span class="item-attackRoll" data-item-id="{{item._id}}"><i class="fas fa-dice-d20"></i> {{item.description.tohit~}}</span>
 			</span>{{ localize "MOBLOKS5E.Comma" }}
 			<span>
 				{{ item.description.range }}{{ localize "MOBLOKS5E.Comma" }}
@@ -33,17 +30,15 @@
 					{{#unless @first}}
 						{{ localize "MOBLOKS5E.MultiDamageAttackConjunctionPlus" }}						
 					{{/unless}}
-					{{> "modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs" text=part.text name=../item.name formula=part.formula}}
+					{{part.average}}
+					(<span class="item-damageRoll" data-item-id="{{../item._id}}"><i class="fas fa-dice-d20"></i> {{part.formula}}</span>)
+					{{moblok-toLowerCase type}}
 					{{ localize "MOBLOKS5E.damage" }}
 					{{~#if (and @first ../item.description.versatile)~}}
-						{{ localize "MOBLOKS5E.Comma" }}
-						{{> "modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs" 
-							name=../item.name 
-							formula=../item.description.versatile.formula
-							text=(	localize "MOBLOKS5E.AttackVersatile"
-									damage=../item.description.versatile.text
-							)
-						}}
+						{{ localize "MOBLOKS5E.Comma" }} {{ localize "MOBLOKS5E.Or" }} {{../item.description.versatile.average}}
+						(<span class="item-damageRoll" data-item-id="{{../item._id}}" data-versatile="true"><i class="fas fa-dice-d20"></i> {{../item.description.versatile.formula}}</span>)
+						{{moblok-toLowerCase type}}
+						{{ localize "MOBLOKS5E.damageVersatile" }}
 						{{~#unless @last}}{{ localize "MOBLOKS5E.Comma" }} {{/unless~}}
 					{{~/if~}}
 				{{~/each~}}			
@@ -51,8 +46,7 @@
 			{{~#unless item.continuousDescription~}}
 				{{ localize "MOBLOKS5E.FullStop" }}
 			{{/unless~}}
-		</span>
+			<span class="description">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</span>
 		{{~/if~}}
-		<span class="description">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</span>
 	</div>
 </section>

--- a/templates/dnd5e/parts/main/lairActs.hbs
+++ b/templates/dnd5e/parts/main/lairActs.hbs
@@ -1,13 +1,7 @@
 <h2 class="section-header">{{ localize "MOBLOKS5E.LairActionsHeading" }}</h2>
 <section>
-	<p class="lair-description">{{ localize "MOBLOKS5E.LairText" name=actor.name }}</p>
-	<ul>
+	<p class="special-description">{{ localize "MOBLOKS5E.LairText" name=actor.name }}</p>
 	{{#each features.lair.items as |item iid|}}
-		{{#if item.is.lair}}
-		<li>
-			{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor lairactions=true flags=@root.flags}}
-		</li>
-		{{/if}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor lairactions=true flags=@root.flags}}
 	{{/each}}
-	</ul>
 </section>

--- a/templates/dnd5e/parts/main/legendaryActs.hbs
+++ b/templates/dnd5e/parts/main/legendaryActs.hbs
@@ -20,13 +20,13 @@
 	{{/if}}
 </h2>
 <section>
-	<p class="legendary-description">
+	<p class="special-description">
 		{{ localize "MOBLOKS5E.LegendaryText" name=actor.name number=data.resources.legact.max}}
 	</p>
 	{{#each features.legendary.items as |item iid|}}
 		{{#if item.is.legendary }}
 		{{#unless item.is.legResist}}
-			{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor legendaryactions=true flags=@root.flags}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item actor=@root.actor specialaction=true flags=@root.flags}}
 		{{/unless}}
 		{{/if}}
 	{{/each}}

--- a/templates/dnd5e/parts/main/regionActs.hbs
+++ b/templates/dnd5e/parts/main/regionActs.hbs
@@ -1,0 +1,12 @@
+<h2 class="section-header">{{ localize "MOBLOKS5E.RegionHeading" }}</h2>
+<section>
+	{{#if features.regionStart.items}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/main/regionCap.hbs" item=features.regionStart.items.[0] actor=@root.actor flags=@root.flags}}
+	{{/if}}
+	{{#each features.region.items as |item iid|}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/featureBlock.hbs" item=item specialaction=true actor=@root.actor flags=@root.flags}}
+	{{/each}}
+	{{#if features.regionEnd.items}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/main/regionCap.hbs" item=features.regionEnd.items.[0] actor=@root.actor flags=@root.flags}}
+	{{/if}}
+</section> 

--- a/templates/dnd5e/parts/main/regionCap.hbs
+++ b/templates/dnd5e/parts/main/regionCap.hbs
@@ -1,0 +1,8 @@
+<section class="item{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
+    {{#if @root.flags.show-delete}}
+        <a class="delete-item" data-item-id="{{item._id}}">
+            <i class="fa fa-trash"></i>
+        </a>
+        <p class="special-description item-name" data-item-id="{{item._id}}">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</p>
+    {{/if}}
+</section> 

--- a/templates/dnd5e/parts/main/variantInfo.hbs
+++ b/templates/dnd5e/parts/main/variantInfo.hbs
@@ -1,0 +1,16 @@
+<h2 class="section-header">{{ localize "MOBLOKS5E.VariantHeading" }}</h2>
+<section>
+{{#each features.variant.items as |item iid|}}
+    <section class="item{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
+        {{#if @root.flags.show-delete}}
+            <a class="delete-item" data-item-id="{{item._id}}">
+                <i class="fa fa-trash"></i>
+            </a>
+        {{/if}}
+        <div class="whitebox">
+            <p class="item-name" style="font-style: normal" data-item-id="{{item._id}}">{{~item.name~}}<span class="headerspan">{{item.data.source}}</span></p>
+            <span class="description">{{{moblok-enrichhtml item.data.description.value @root.owner @root.flags}}}</span>
+        </div>
+    </section>
+{{/each}}
+</section> 

--- a/templates/dnd5e/switches.hbs
+++ b/templates/dnd5e/switches.hbs
@@ -20,139 +20,105 @@
 				off="MOBLOKS5E.EnableDelete"
 			}}
 		{{/if}}
-		<li>
-			<a class="switch" data-control="show-resources">
-				{{~#if flags.show-resources}}
-					{{~ localize "MOBLOKS5E.HideResources" ~}}
-				{{~else}}
-					{{~ localize "MOBLOKS5E.ShowResources" ~}}
-				{{~/if~}}
-			</a>
-		</li>
-		<li>
-			<a class="switch" data-control="show-skill-save">
-				{{~#if flags.show-skill-save}}
-				{{~ localize "MOBLOKS5E.HideSkillSave" ~}}
-				{{~else}}
-				{{~ localize "MOBLOKS5E.ShowSkillSave" ~}}
-				{{~/if~}}
-			</a>
-		</li>
-		<li>
-			<a class="switch" data-control="show-not-prof">
-				{{~#if flags.show-not-prof}}
-					{{~ localize "MOBLOKS5E.HideNotProf" ~}}
-				{{~else}}
-					{{~ localize "MOBLOKS5E.ShowNotProf" ~}}
-				{{~/if~}}
-			</a>
-		</li>
-		<li>
-			<a class="switch" data-control="attack-descriptions">
-				{{ localize "MOBLOKS5E.AttackDescriptions" }}
-			</a>
-			<ul>
-				<li>
-					<a class="switch" data-control="attack-descriptions">
-						{{~#if flags.attack-descriptions}}
-							{{~ localize "MOBLOKS5E.HideGenerated" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.ShowGenerated" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-			</ul>
-		</li>
-		{{#if info.hasCastingFeature}}
-		<li>
-			<a class="switch" data-control="casting-feature">{{ localize "DND5E.Spellcasting" }}</a>
-			<ul>
-				<li>
-					<a class="switch" data-control="casting-feature">
-						{{~#if flags.casting-feature~}}
-							{{~ localize "MOBLOKS5E.HideGenerated" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.ShowGenerated" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-			</ul>
-		</li>
-		{{/if}}
-		<li>
-			<a>{{ localize "MOBLOKS5E.DescriptionS" }}</a>
-			<ul>
-				<li>
-					<a class="switch" data-control="inline-secrets">
-						{{~#if flags.inline-secrets~}}
-							{{~ localize "MOBLOKS5E.DisableInlSecr" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.EnableInlSecr" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="hidden-secrets">
-						{{~#if flags.hidden-secrets~}}
-							{{~ localize "MOBLOKS5E.ShowSecrets" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.HideSecrets" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-			</ul>
-		</li>
-		<li>
-			<a>{{ localize "DND5E.HitPoints" }}</a>
-			<ul>
-				<li>
-					<a class="switch" data-control="current-hit-points">
-						{{~#if flags.current-hit-points~}}
-							{{~ localize "MOBLOKS5E.HideCurrentHP" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.ShowCurrentHP" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="maximum-hit-points">
-						{{~#if flags.maximum-hit-points~}}
-							{{~ localize "MOBLOKS5E.HideMaxHP" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.ShowMaxHP" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-			</ul>
-		</li>
-		<li>
-			<a class="switch" data-control="hide-profile-image">
-				{{~#if flags.hide-profile-image~}}
-					{{ localize "MOBLOKS5E.ShowProfileImage" ~}}
-				{{~else~}}
-					{{ localize "MOBLOKS5E.HideProfileImage" ~}}
-				{{~/if~}}
-			</a>
-		</li>
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+				flag=flags.show-bio
+				control="show-bio" 
+				on="MOBLOKS5E.HideBio" 
+				off="MOBLOKS5E.ShowBio"
+		}}
 		{{#if info.hasLair}}
-		<li>
-			<a class="switch" data-control="show-lair-actions">
-				{{~#if flags.show-lair-actions~}}
-					{{ localize "MOBLOKS5E.HideLair" ~}}
-				{{~else~}}
-					{{ localize "MOBLOKS5E.ShowLair" ~}}
-				{{~/if~}}
-			</a>
-		</li>
+			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+				flag=flags.show-lair-actions
+				control="show-lair-actions" 
+				on="MOBLOKS5E.HideLair"
+				off="MOBLOKS5E.ShowLair"
+			}}
+		{{/if}}
+		{{#if info.hasRegion}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+				flag=flags.show-region-actions
+				control="show-region-actions" 
+				on="MOBLOKS5E.HideRegion"
+				off="MOBLOKS5E.ShowRegion"
+			}}
+		{{/if}}
+		{{#if info.hasVariant}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+				flag=flags.show-variant
+				control="show-variant"
+				on="MOBLOKS5E.HideVariant"
+				off="MOBLOKS5E.ShowVariant"
+			}}
 		{{/if}}
 		<li>
-			<a class="switch" data-control="show-bio">
-				{{~#if flags.show-bio~}}
-					{{ localize "MOBLOKS5E.HideBio" ~}}
-				{{~else~}}
-					{{ localize "MOBLOKS5E.ShowBio" ~}}
-				{{~/if~}}
-			</a>
+			<a class="trigger" data-control="resetDefaults">{{ localize "MOBLOKS5E.resetDefaults.label" }}</a>
+		</li>
+		<li>
+			<a>Hide / Show</a>
+			<ul>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.hide-profile-image
+					control="hide-profile-image" 
+					on="MOBLOKS5E.ShowProfileImage" 
+					off="MOBLOKS5E.HideProfileImage"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.current-hit-points
+					control="current-hit-points" 
+					on="MOBLOKS5E.HideCurrentHP" 
+					off="MOBLOKS5E.ShowCurrentHP"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.maximum-hit-points
+					control="maximum-hit-points" 
+					on="MOBLOKS5E.HideMaxHP" 
+					off="MOBLOKS5E.ShowMaxHP"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.show-resources
+					control="show-resources" 
+					on="MOBLOKS5E.HideResources" 
+					off="MOBLOKS5E.ShowResources"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.show-skill-save
+					control="show-skill-save" 
+					on="MOBLOKS5E.HideSkillSave" 
+					off="MOBLOKS5E.ShowSkillSave"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.show-not-prof
+					control="show-not-prof" 
+					on="MOBLOKS5E.HideNotProf" 
+					off="MOBLOKS5E.ShowNotProf"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.attack-descriptions
+					control="attack-descriptions" 
+					on="Hide generated attacks"
+					off="Show generated attacks"
+				}}
+				{{#if info.hasCastingFeature}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.casting-feature
+					control="casting-feature" 
+					on="Hide generated spellcasting"
+					off="Show generated spellcasting"
+				}}
+				{{/if}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.inline-secrets
+					control="inline-secrets" 
+					on="MOBLOKS5E.DisableInlSecr"
+					off="MOBLOKS5E.EnableInlSecr"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.hidden-secrets
+					control="hidden-secrets" 
+					on="MOBLOKS5E.ShowSecrets"
+					off="MOBLOKS5E.HideSecrets"
+				}}
+			</ul>
 		</li>
 		{{#if info.vttatokenizer}}
 		<li>
@@ -160,39 +126,27 @@
 		</li>
 		{{/if}}
 		<li>
-			<a class="trigger" data-control="resetDefaults">{{ localize "MOBLOKS5E.resetDefaults.label" }}</a>
-		</li>
-		<li>
-			<a>{{localize "MOBLOKS5E.mini-block.label"}}</a>
+			<a>Display</a>
 			<ul>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+						flag=flags.compact-window
+						control="compact-window" 
+						on="MOBLOKS5E.compact-window.disable" 
+						off="MOBLOKS5E.compact-window.enable"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+						flag=flags.compact-layout
+						control="compact-layout" 
+						on="MOBLOKS5E.compact-layout.disable" 
+						off="MOBLOKS5E.compact-layout.enable"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+						flag=flags.compact-feats
+						control="compact-feats" 
+						on="MOBLOKS5E.compact-feats.disable" 
+						off="MOBLOKS5E.compact-feats.enable"
+				}}
 				<li>
-					<a class="switch" data-control="compact-window">
-						{{~#if flags.compact-window}}
-							{{~ localize "MOBLOKS5E.compact-window.disable" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.compact-window.enable" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="compact-layout">
-						{{~#if flags.compact-layout}}
-							{{~ localize "MOBLOKS5E.compact-layout.disable" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.compact-layout.enable" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="compact-feats">
-						{{~#if flags.compact-feats}}
-							{{~ localize "MOBLOKS5E.compact-feats.disable" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.compact-feats.enable" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>		
 					<label>
 						<a class="trigger nochild" data-control="setFontSize">
 							{{~ localize "MOBLOKS5E.font-size.label" }}{{ localize "MOBLOKS5E.Colon" ~}}
@@ -200,31 +154,31 @@
 						<input type="text" class="switch-input" placeholder="{{localize "MOBLOKS5E.font-size.placeholder"}}" value="{{flags.font-size}}">
 					</label>
 				</li>
-			</ul>
-		</li>
-		<li>
-			<a>{{ localize "MOBLOKS5E.Theme" }}</a>
-			<ul>
-			{{#each themes as |theme id|}}
-			{{#unless (eq id "custom")}}
 				<li>
-					<a	class="trigger{{#if (eq @root.flags.theme-choice id)}} selected{{/if}}"
-						data-control="pickTheme" 
-						data-value="{{id}}">
-						{{~ localize theme.name ~}}
-					</a>
-				</li>
-			{{/unless}}
-			{{/each}}
-				<li>
-					<label class="custom-class-label{{#if (eq flags.theme-choice 'custom')}} selected{{/if}}">
-						<a	class="trigger nochild" 
-							data-control="pickTheme" 
-							data-value="custom">
-							{{~ localize "MOBLOKS5E.CustomThemeName" }}{{ localize "MOBLOKS5E.Colon" ~}}
-						</a>
-						<input type="text" class="switch-input" placeholder="class-name" value="{{flags.custom-theme-class}}">
-					</label>
+					<a>{{ localize "MOBLOKS5E.Theme" }}</a>
+					<ul>
+					{{#each themes as |theme id|}}
+					{{#unless (eq id "custom")}}
+						<li>
+							<a	class="trigger{{#if (eq @root.flags.theme-choice id)}} selected{{/if}}"
+								data-control="pickTheme" 
+								data-value="{{id}}">
+								{{~ localize theme.name ~}}
+							</a>
+						</li>
+					{{/unless}}
+					{{/each}}
+						<li>
+							<label class="custom-class-label{{#if (eq flags.theme-choice 'custom')}} selected{{/if}}">
+								<a	class="trigger nochild" 
+									data-control="pickTheme" 
+									data-value="custom">
+									{{~ localize "MOBLOKS5E.CustomThemeName" }}{{ localize "MOBLOKS5E.Colon" ~}}
+								</a>
+								<input type="text" class="switch-input" placeholder="class-name" value="{{flags.custom-theme-class}}">
+							</label>
+						</li>
+					</ul>
 				</li>
 			</ul>
 		</li>


### PR DESCRIPTION
This resolves issue #54 

- When bludgeoning, piercing, and slashing from nonmagical attacks is selected, it always appears at the end of the list
- This damage type is always preceded by a semi-colon
- Does not display a semi-colon if it is the only resistance type selected

![image](https://user-images.githubusercontent.com/7407481/155054224-4988bb36-30db-4a95-8b05-9a1000febc6b.png)