### PR TITLE
Resolves issue #54 Nonmagical Attacks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -233,6 +233,7 @@
 		"SpeedUnitAbbrEnd": ".",
 		"Comma": ",",
 		"Colon": ":",
+		"SemiColon": ";",
 		
 		"Cantrips": "Cantrips",
 		"AtWill": "at will",

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1209,6 +1209,9 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
+		},
+		"moblok-equals": (val, compare) => {
+			return val === compare;
 		}
 	};
 

--- a/templates/dnd5e/parts/header/attributes/damage.hbs
+++ b/templates/dnd5e/parts/header/attributes/damage.hbs
@@ -3,10 +3,20 @@
 		<span class="attribute-wrapper">
 			<h4 class="attribute-name">{{localize label}}</h4>
 			<ul class="traits-list inline-list no-caps">
-				{{#each damage as |v k|}}
-					<li class="trait-value">{{v}}</li>
-				{{/each}}
+				{{~#each damage as |v k|~}}
+					{{~#unless (moblok-equals k "physical")~}}
+						<li class="trait-value">{{v}}</li>
+					{{~/unless~}}
+				{{~/each~}}
 			</ul>
+			{{~#each damage as |v k|~}}
+				{{~#if (moblok-equals k "physical")~}}
+					<span>
+						{{~#unless (moblok-equals @index 0)~}}; {{/unless}}
+						{{v}}
+					</span>
+				{{~/if~}}
+			{{~/each~}}
 		</span>
 	</li>
 {{/if}}

--- a/templates/dnd5e/parts/header/attributes/damage.hbs
+++ b/templates/dnd5e/parts/header/attributes/damage.hbs
@@ -12,7 +12,7 @@
 			{{~#each damage as |v k|~}}
 				{{~#if (moblok-equals k "physical")~}}
 					<span>
-						{{~#unless (moblok-equals @index 0)~}}; {{/unless}}
+						{{~#unless (moblok-equals @index 0)~}}{{ localize "MOBLOKS5E.SemiColon"}}{{/unless}}
 						{{v}}
 					</span>
 				{{~/if~}}


### PR DESCRIPTION
This resolves #54 Nonmagical attacks

- When bludgeoning, piercing, and slashing from nonmagical attacks is selected, it always appears at the end of the list
- This damage type is always preceded by a semi-colon
- Does not display a semi-colon if it is the only resistance type selected

![image](https://user-images.githubusercontent.com/7407481/155054224-4988bb36-30db-4a95-8b05-9a1000febc6b.png)