### PR TITLE
Resolves #152 Use default rolls for Attack and Damage

### DIFF
--- a/monsterblock.css
+++ b/monsterblock.css
@@ -239,6 +239,8 @@
 	height: 1em;
 	padding: 0;
 }
+.monsterblock .item-attackRoll:hover,
+.monsterblock .item-damageRoll:hover,
 .monsterblock .ability:hover, 
 .monsterblock .saving-throw:hover, 
 .monsterblock .skill:hover, 

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -787,6 +787,29 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			}
 			else return item.roll(); // Conveniently, items have all this logic built in already.
 		});
+
+		// uses the built in attack roll from the item
+		// uses mousedown to prevent highlighting of text when using shift modifier
+		html.find(".item-attackRoll").mousedown(async (event) => {
+			event.preventDefault();
+
+			let id = event.currentTarget.dataset.itemId;
+			const item = this.actor.items.get(id);
+
+			item.rollAttack({event});
+		});
+
+		// uses the built in damage roll from the item
+		// uses mousedown to prevent highlighting of text when using shift modifier
+		html.find(".item-damageRoll").mousedown(async (event) => {
+			event.preventDefault();
+
+			let id = event.currentTarget.dataset.itemId;
+			let versatile = event.currentTarget.dataset.versatile;
+			const item = this.actor.items.get(id);
+
+			item.rollDamage({event, versatile});
+		})
 		
 		// Item editing handlers. Allows right clicking on the description of any item (features, action, etc.) to open its own sheet to edit.
 		html.find(".item").contextmenu(this.openItemEditor.bind(this));

--- a/templates/dnd5e/parts/damageRoll.hbs
+++ b/templates/dnd5e/parts/damageRoll.hbs
@@ -1,5 +1,5 @@
-<span class="attack-damage" 
-	data-roll-flavor="{{localize 'DND5E.Damage'}}: {{name}}"
-	data-roll-formula="{{formula}}">
+<span class="item-damageRoll"
+	data-item-id="{{id}}"
+	data-versatile={{versatile}} >
 	{{~text~}}
 </span>

--- a/templates/dnd5e/parts/main/attack.hbs
+++ b/templates/dnd5e/parts/main/attack.hbs
@@ -12,9 +12,7 @@
 		{{ localize "MOBLOKS5E.NameDescriptionSep" }}
 		{{#if @root.flags.attack-descriptions}}
 		<span class="generated-text">			
-			<span class="attack-bonus" 
-				data-roll-flavor="{{ localize "DND5E.Attack" }}: {{item.name}}" 
-				data-roll-formula="1d20 + {{item.tohit}}">
+			<span class="item-attackRoll" data-item-id="{{item._id}}">
 				<span class="attack-type">
 					{{~item.description.attackType~}}
 					{{ localize "MOBLOKS5E.Colon" }}
@@ -33,13 +31,13 @@
 					{{#unless @first}}
 						{{ localize "MOBLOKS5E.MultiDamageAttackConjunctionPlus" }}						
 					{{/unless}}
-					{{> "modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs" text=part.text name=../item.name formula=part.formula}}
+					{{> "modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs" id=../item._id text=part.text }}
 					{{ localize "MOBLOKS5E.damage" }}
 					{{~#if (and @first ../item.description.versatile)~}}
 						{{ localize "MOBLOKS5E.Comma" }}
-						{{> "modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs" 
-							name=../item.name 
-							formula=../item.description.versatile.formula
+						{{> "modules/monsterblock/templates/dnd5e/parts/damageRoll.hbs"
+							id=../item._id
+							versatile=true
 							text=(	localize "MOBLOKS5E.AttackVersatile"
 									damage=../item.description.versatile.text
 							)


### PR DESCRIPTION
Resolves #152 Use default rolls for Attack and Damage

- Changes both the attack and damage rolls of weapons to use the 5e system built in rolls
- Allows use of the modifiers, and selection of advantage, disadvantage and critical damage choices
- Supports use of fast-forward hotkeys built into the 5e system (Shift = normal roll, Alt = advantage / critical, Ctrl = disadvantage)
- Uses `.mousedown` as opposed to `.click` with `event.preventDefault()` to avoid highlighting text when shift + clicking text

Notes:
- Uses the current `damageRoll.hbs` part, although, I believe with the shorter syntax required, this part could be removed, and the `span` could be added to `attack.hbs`. It's almost more complicated to pass parameters to such a small part, than to just add it to the parent part.

https://user-images.githubusercontent.com/7407481/155200650-7e737f1c-ba75-4e36-973b-8340939084da.mp4