### PR TITLE
Add switch to show token image instead of profile image

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -161,6 +161,7 @@
 		"HideMaxHP": "Hide maximum hit points",
 		"ShowCurrentHP": "Show current hit points",
 		"HideCurrentHP": "Hide current hit points",
+		"ProfileImage": "Profile Image",
 		"ShowProfileImage": "Show profile image",
 		"HideProfileImage": "Hide profile image",
 		"UseTokenImage": "Use token image",

--- a/lang/en.json
+++ b/lang/en.json
@@ -162,6 +162,8 @@
 		"HideCurrentHP": "Hide current hit points",
 		"ShowProfileImage": "Show profile image",
 		"HideProfileImage": "Hide profile image",
+		"UseTokenImage": "Use token image",
+		"UseProfileImage": "Use profile image",
 		"ShowLair": "Show lair actions",
 		"HideLair": "Hide lair actions",
 		"OpenTokenizer": "Open VTTA Tokenizer",

--- a/scripts/Flags.js
+++ b/scripts/Flags.js
@@ -22,6 +22,7 @@ export default class Flags {
 			"inline-secrets"    : { type: Boolean, default: false    , hidden: false },
 			"hidden-secrets"    : { type: Boolean, default: false    , hidden: false },
 			"hide-profile-image": { type: Boolean, default: false    , hidden: false },
+			"use-token-image"   : { type: Boolean, default: false    , hidden: false },
 			"theme-choice"      : { type: String , default: "default", hidden: true, setting: "default-theme" },
 			"custom-theme-class": { type: String , default: ""       , hidden: false },
 			"editing"           : { type: Boolean, default: true     , hidden: false },

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -168,7 +168,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		}
 
 		// Process editable images
-		const images = form.querySelectorAll("img[data-edit]")
+		const images = form.querySelectorAll("img[data-edit], token.img[edit-data]")
 		for (let img of images) {
 			if (img.getAttribute("disabled")) continue;
 			let basePath = window.location.origin + "/";
@@ -631,6 +631,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			"current-hit-points": game.settings.get("monsterblock", "current-hit-points"),
 			"maximum-hit-points": game.settings.get("monsterblock", "maximum-hit-points"),
 			"hide-profile-image": game.settings.get("monsterblock", "hide-profile-image"),
+			"use-token-image": false,
 			"show-lair-actions": game.settings.get("monsterblock", "show-lair-actions"),
 			"theme-choice": game.settings.get("monsterblock", "default-theme"),
 			"custom-theme-class": game.settings.get("monsterblock", "custom-theme-class"),
@@ -687,7 +688,9 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		html.find(".profile-image").click((event) => {
 			event.preventDefault();
 
-			new ImagePopout(this.actor.data.img, {
+			console.log(event);
+
+			new ImagePopout(event.target.currentSrc, {
 				title: this.actor.name,
 				shareable: true,
 				uuid: this.actor.uuid
@@ -870,6 +873,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			// Detect and activate TinyMCE rich text editors
 			html.find(".editor-content[data-edit]").each((i, div) => this._activateEditor(div));
 			html.find("img[data-edit]").contextmenu(ev => this._onEditImage(ev));
+			html.find("token.img[data-edit]").contextmenu(ev => this._onEditImage(ev));
 		}
 		
 		if (!this.lastSelection) this.lastSelection = {};

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -168,7 +168,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		}
 
 		// Process editable images
-		const images = form.querySelectorAll("img[data-edit], token.img[edit-data]")
+		const images = form.querySelectorAll("img[data-edit], token.img[data-edit]")
 		for (let img of images) {
 			if (img.getAttribute("disabled")) continue;
 			let basePath = window.location.origin + "/";
@@ -687,8 +687,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		});
 		html.find(".profile-image").click((event) => {
 			event.preventDefault();
-
-			console.log(event);
 
 			new ImagePopout(event.target.currentSrc, {
 				title: this.actor.name,

--- a/templates/dnd5e/parts/header/identity.hbs
+++ b/templates/dnd5e/parts/header/identity.hbs
@@ -24,10 +24,12 @@
 </div>
 {{#unless flags.hide-profile-image}}
 	<figure class="profile-image">
-		{{#if flags.use-token-image}}
-			<img src="{{actor.token.img}}" data-edit="token.img" title="{{actor.name}}{{#if flags.editing}} - {{ localize "MOBLOKS5E.EditHint" }}{{/if}}">
-		{{else}}
-			<img src="{{actor.img}}" data-edit="img" title="{{actor.name}}{{#if flags.editing}} - {{ localize "MOBLOKS5E.EditHint" }}{{/if}}">
-		{{/if}}
+			<img 
+				{{#if flags.use-token-image}}
+					src="{{actor.token.img}}" data-edit="token.img"
+				{{else}}
+					src="{{actor.img}}" data-edit="img"
+				{{/if}}
+				title="{{actor.name}}{{#if flags.editing}} - {{ localize "MOBLOKS5E.EditHint" }}{{/if}}">
 	</figure>
 {{/unless}}

--- a/templates/dnd5e/parts/header/identity.hbs
+++ b/templates/dnd5e/parts/header/identity.hbs
@@ -24,7 +24,10 @@
 </div>
 {{#unless flags.hide-profile-image}}
 	<figure class="profile-image">
-		<img src="{{actor.img}}" data-edit="img"
-			title="{{actor.name}}{{#if flags.editing}} - {{ localize "MOBLOKS5E.EditHint" }}{{/if}}">
+		{{#if flags.use-token-image}}
+			<img src="{{actor.token.img}}" data-edit="token.img" title="{{actor.name}}{{#if flags.editing}} - {{ localize "MOBLOKS5E.EditHint" }}{{/if}}">
+		{{else}}
+			<img src="{{actor.img}}" data-edit="img" title="{{actor.name}}{{#if flags.editing}} - {{ localize "MOBLOKS5E.EditHint" }}{{/if}}">
+		{{/if}}
 	</figure>
 {{/unless}}

--- a/templates/dnd5e/parts/switch.hbs
+++ b/templates/dnd5e/parts/switch.hbs
@@ -6,4 +6,7 @@
 			{{~ localize off ~}}
 		{{~/if~}}
 	</a>
+	{{#if @partial-block}}
+		{{> @partial-block }}
+	{{/if}}
 </li>

--- a/templates/dnd5e/switches.hbs
+++ b/templates/dnd5e/switches.hbs
@@ -86,18 +86,33 @@
 			</ul>
 		</li>
 		
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+		{{#> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
 			flag=flags.hide-profile-image
-			control="hide-profile-image" 
-			on="MOBLOKS5E.ShowProfileImage" 
-			off="MOBLOKS5E.HideProfileImage"
+			control="hide-profile-image"
+			on="MOBLOKS5E.ProfileImage"
+			off="MOBLOKS5E.ProfileImage"
 		}}
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
-			flag=flags.use-token-image
-			control="use-token-image"
-			on="MOBLOKS5E.UseProfileImage"
-			off="MOBLOKS5E.UseTokenImage"
-		}}
+			<ul>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
+					flag=flags.hide-profile-image
+					control="hide-profile-image"
+					on="MOBLOKS5E.ShowProfileImage"
+					off="MOBLOKS5E.HideProfileImage"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
+					flag=flags.use-token-image
+					control="use-token-image"
+					on="MOBLOKS5E.UseProfileImage"
+					off="MOBLOKS5E.UseTokenImage"
+				}}
+				{{#if info.vttatokenizer}}
+					{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
+						control="openTokenizer"
+						title="MOBLOKS5E.OpenTokenizer"
+					}}
+				{{/if}}
+			</ul>
+		{{/"modules/monsterblock/templates/dnd5e/parts/switch.hbs"}}
 		
 		{{#if info.hasLair}}
 			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
@@ -113,12 +128,6 @@
 			on="MOBLOKS5E.HideBio" 
 			off="MOBLOKS5E.ShowBio"
 		}}
-		{{#if info.vttatokenizer}}
-			{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
-				control="openTokenizer"
-				title="MOBLOKS5E.OpenTokenizer"
-			}}
-		{{/if}}
 		{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
 			control="resetDefaults"
 			title="MOBLOKS5E.resetDefaults.label"

--- a/templates/dnd5e/switches.hbs
+++ b/templates/dnd5e/switches.hbs
@@ -133,6 +133,16 @@
 					{{ localize "MOBLOKS5E.HideProfileImage" ~}}
 				{{~/if~}}
 			</a>
+			{{#unless flags.hide-profile-image}}
+			<ul>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
+					flag=flags.use-token-image
+					control="use-token-image"
+					on="MOBLOKS5E.UseProfileImage"
+					off="MOBLOKS5E.UseTokenImage"
+				}}
+			</ul>
+			{{/unless}}
 		</li>
 		{{#if info.hasLair}}
 		<li>


### PR DESCRIPTION
I added this to my local copy, and thought it may be of use for the public copy, let me know what you think. This adds the ability to switch the image on the main page between the profile image and the token image. I've found sometimes the profile images I use are large and distracting, where a token image is a bit cleaner. I am not changing the image used on the bio page, as I think that image is likely always going to be the profile image.

This also has a few added benefits. You can change the token image easily from the character sheet instead of having to choose the token cog from the top of the sheet, then navigate to the appearance tab of the token menu to set it. You can also use this to open the token image on screen and share it with the players; this is not something you can actually do with the default 5e system.

For control, instead of adding another toggle to the dropdown, I added this as a flyout from show profile image; wording which may need to be changed if this is implemented, because it wouldn't strictly be a profile image anymore. If the show profile image option is off, this flyout doesn't appear, sort of like how show delete doesn't appear unless you're editing the sheet.

On my local copy, I've included a system option for this so you can set the default of how you want this to work. For this PR I just set the default to false.

https://user-images.githubusercontent.com/7407481/155570206-7af3e181-e77b-4ab3-ba3d-89112cb28ead.mp4