### PR TITLE
Resolves #158 Add switch partials to switches.hbs

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -135,7 +135,6 @@
 		
 		"SwitchToDefault": "Switch to Default Sheet",
 		"SwitchToMobloks": "Switch to Monster Blocks",
-		"AttackDescriptions": "Attack descriptions",
 		
 		"EnableEdit": "Enable editing",
 		"DisableEdit": "Disable editing",
@@ -149,8 +148,10 @@
 		"HideBio": "Hide Biography",
 		"ShowResources": "Show Resource Values",
 		"HideResources": "Hide Resource Values",
-		"ShowGenerated": "Show generated",
-		"HideGenerated": "Hide generated",
+		"HideGeneratedAttack": "Hide generated attack",
+		"ShowGeneratedAttack": "Show generated attack",
+		"HideGeneratedSpellcasting": "Hide generated spellcasting",
+		"ShowGeneratedSpellcasting": "Show generated spellcasting",
 		"DescriptionS": "Descriptions",
 		"EnableInlSecr": "Enable inline secrets",
 		"DisableInlSecr": "Disable inline secrets",

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1220,6 +1220,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			// Shared Partials
 			"modules/monsterblock/templates/dnd5e/switches.hbs",
 			"modules/monsterblock/templates/dnd5e/parts/switch.hbs",
+			"modules/monsterblock/templates/dnd5e/parts/trigger.hbs",
 
 			// Actor Sheet Sections
 			"modules/monsterblock/templates/dnd5e/bio.hbs",

--- a/templates/dnd5e/parts/trigger.hbs
+++ b/templates/dnd5e/parts/trigger.hbs
@@ -1,0 +1,7 @@
+<li>
+    <a class="trigger{{#if selected}} selected{{/if}}"
+        data-control="{{control}}"
+        data-value="{{value}}">
+        {{~ localize title ~}}
+    </a>
+</li>

--- a/templates/dnd5e/switches.hbs
+++ b/templates/dnd5e/switches.hbs
@@ -1,11 +1,10 @@
 <nav class="switches">
 	<i class="fas fa-cog"></i>
 	<ul>
-		<li>
-			<a class="trigger" data-control="switchToDefault">
-				{{ localize "MOBLOKS5E.SwitchToDefault" }}
-			</a>
-		</li>
+		{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
+			control="switchToDefault"
+			title="MOBLOKS5E.SwitchToDefault"
+		}}
 		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
 			flag=flags.editing 
 			control="editing" 
@@ -20,179 +19,124 @@
 				off="MOBLOKS5E.EnableDelete"
 			}}
 		{{/if}}
-		<li>
-			<a class="switch" data-control="show-resources">
-				{{~#if flags.show-resources}}
-					{{~ localize "MOBLOKS5E.HideResources" ~}}
-				{{~else}}
-					{{~ localize "MOBLOKS5E.ShowResources" ~}}
-				{{~/if~}}
-			</a>
-		</li>
-		<li>
-			<a class="switch" data-control="show-skill-save">
-				{{~#if flags.show-skill-save}}
-				{{~ localize "MOBLOKS5E.HideSkillSave" ~}}
-				{{~else}}
-				{{~ localize "MOBLOKS5E.ShowSkillSave" ~}}
-				{{~/if~}}
-			</a>
-		</li>
-		<li>
-			<a class="switch" data-control="show-not-prof">
-				{{~#if flags.show-not-prof}}
-					{{~ localize "MOBLOKS5E.HideNotProf" ~}}
-				{{~else}}
-					{{~ localize "MOBLOKS5E.ShowNotProf" ~}}
-				{{~/if~}}
-			</a>
-		</li>
-		<li>
-			<a class="switch" data-control="attack-descriptions">
-				{{ localize "MOBLOKS5E.AttackDescriptions" }}
-			</a>
-			<ul>
-				<li>
-					<a class="switch" data-control="attack-descriptions">
-						{{~#if flags.attack-descriptions}}
-							{{~ localize "MOBLOKS5E.HideGenerated" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.ShowGenerated" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-			</ul>
-		</li>
-		{{#if info.hasCastingFeature}}
-		<li>
-			<a class="switch" data-control="casting-feature">{{ localize "DND5E.Spellcasting" }}</a>
-			<ul>
-				<li>
-					<a class="switch" data-control="casting-feature">
-						{{~#if flags.casting-feature~}}
-							{{~ localize "MOBLOKS5E.HideGenerated" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.ShowGenerated" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-			</ul>
-		</li>
-		{{/if}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+			flag=flags.show-resources
+			control="show-resources" 
+			on="MOBLOKS5E.HideResources" 
+			off="MOBLOKS5E.ShowResources"
+		}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+			flag=flags.show-skill-save
+			control="show-skill-save" 
+			on="MOBLOKS5E.HideSkillSave" 
+			off="MOBLOKS5E.ShowSkillSave"
+		}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+			flag=flags.show-not-prof
+			control="show-not-prof" 
+			on="MOBLOKS5E.HideNotProf" 
+			off="MOBLOKS5E.ShowNotProf"
+		}}
 		<li>
 			<a>{{ localize "MOBLOKS5E.DescriptionS" }}</a>
 			<ul>
-				<li>
-					<a class="switch" data-control="inline-secrets">
-						{{~#if flags.inline-secrets~}}
-							{{~ localize "MOBLOKS5E.DisableInlSecr" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.EnableInlSecr" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="hidden-secrets">
-						{{~#if flags.hidden-secrets~}}
-							{{~ localize "MOBLOKS5E.ShowSecrets" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.HideSecrets" ~}}
-						{{~/if~}}
-					</a>
-				</li>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
+					flag=flags.attack-descriptions
+					control="attack-descriptions"
+					on="MOBLOKS5E.HideGeneratedAttack"
+					off="MOBLOKS5E.ShowGeneratedAttack"
+				}}
+				{{#if info.hasCastingFeature}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.casting-feature
+					control="casting-feature" 
+					on="MOBLOKS5E.HideGeneratedSpellcasting" 
+					off="MOBLOKS5E.ShowGeneratedSpellcasting"
+				}}
+				{{/if}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.inline-secrets
+					control="inline-secrets" 
+					on="MOBLOKS5E.DisableInlSecr" 
+					off="MOBLOKS5E.EnableInlSecr"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.hidden-secrets
+					control="hidden-secrets" 
+					on="MOBLOKS5E.ShowSecrets" 
+					off="MOBLOKS5E.HideSecrets"
+				}}
 			</ul>
 		</li>
 		<li>
 			<a>{{ localize "DND5E.HitPoints" }}</a>
 			<ul>
-				<li>
-					<a class="switch" data-control="current-hit-points">
-						{{~#if flags.current-hit-points~}}
-							{{~ localize "MOBLOKS5E.HideCurrentHP" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.ShowCurrentHP" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="maximum-hit-points">
-						{{~#if flags.maximum-hit-points~}}
-							{{~ localize "MOBLOKS5E.HideMaxHP" ~}}
-						{{~else~}}
-							{{~ localize "MOBLOKS5E.ShowMaxHP" ~}}
-						{{~/if~}}
-					</a>
-				</li>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.current-hit-points
+					control="current-hit-points" 
+					on="MOBLOKS5E.HideCurrentHP" 
+					off="MOBLOKS5E.ShowCurrentHP"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.maximum-hit-points
+					control="maximum-hit-points" 
+					on="MOBLOKS5E.HideMaxHP" 
+					off="MOBLOKS5E.ShowMaxHP"
+				}}
 			</ul>
 		</li>
-		<li>
-			<a class="switch" data-control="hide-profile-image">
-				{{~#if flags.hide-profile-image~}}
-					{{ localize "MOBLOKS5E.ShowProfileImage" ~}}
-				{{~else~}}
-					{{ localize "MOBLOKS5E.HideProfileImage" ~}}
-				{{~/if~}}
-			</a>
-		</li>
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+			flag=flags.hide-profile-image
+			control="hide-profile-image" 
+			on="MOBLOKS5E.ShowProfileImage" 
+			off="MOBLOKS5E.HideProfileImage"
+		}}
 		{{#if info.hasLair}}
-		<li>
-			<a class="switch" data-control="show-lair-actions">
-				{{~#if flags.show-lair-actions~}}
-					{{ localize "MOBLOKS5E.HideLair" ~}}
-				{{~else~}}
-					{{ localize "MOBLOKS5E.ShowLair" ~}}
-				{{~/if~}}
-			</a>
-		</li>
+			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+				flag=flags.show-lair-actions
+				control="show-lair-actions" 
+				on="MOBLOKS5E.HideLair" 
+				off="MOBLOKS5E.ShowLair"
+			}}
 		{{/if}}
-		<li>
-			<a class="switch" data-control="show-bio">
-				{{~#if flags.show-bio~}}
-					{{ localize "MOBLOKS5E.HideBio" ~}}
-				{{~else~}}
-					{{ localize "MOBLOKS5E.ShowBio" ~}}
-				{{~/if~}}
-			</a>
-		</li>
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+			flag=flags.show-bio
+			control="show-bio" 
+			on="MOBLOKS5E.HideBio" 
+			off="MOBLOKS5E.ShowBio"
+		}}
 		{{#if info.vttatokenizer}}
-		<li>
-			<a class="trigger" data-control="openTokenizer">{{ localize "MOBLOKS5E.OpenTokenizer" }}</a>
-		</li>
+			{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
+				control="openTokenizer"
+				title="MOBLOKS5E.OpenTokenizer"
+			}}
 		{{/if}}
-		<li>
-			<a class="trigger" data-control="resetDefaults">{{ localize "MOBLOKS5E.resetDefaults.label" }}</a>
-		</li>
+		{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
+			control="resetDefaults"
+			title="MOBLOKS5E.resetDefaults.label"
+		}}
 		<li>
 			<a>{{localize "MOBLOKS5E.mini-block.label"}}</a>
 			<ul>
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.compact-window
+					control="compact-window" 
+					on="MOBLOKS5E.compact-window.disable" 
+					off="MOBLOKS5E.compact-window.enable"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.compact-layout
+					control="compact-layout" 
+					on="MOBLOKS5E.compact-layout.disable" 
+					off="MOBLOKS5E.compact-layout.enable"
+				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
+					flag=flags.compact-feats
+					control="compact-feats" 
+					on="MOBLOKS5E.compact-feats.disable" 
+					off="MOBLOKS5E.compact-feats.enable"
+				}}
 				<li>
-					<a class="switch" data-control="compact-window">
-						{{~#if flags.compact-window}}
-							{{~ localize "MOBLOKS5E.compact-window.disable" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.compact-window.enable" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="compact-layout">
-						{{~#if flags.compact-layout}}
-							{{~ localize "MOBLOKS5E.compact-layout.disable" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.compact-layout.enable" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>
-					<a class="switch" data-control="compact-feats">
-						{{~#if flags.compact-feats}}
-							{{~ localize "MOBLOKS5E.compact-feats.disable" ~}}
-						{{~else}}
-							{{~ localize "MOBLOKS5E.compact-feats.enable" ~}}
-						{{~/if~}}
-					</a>
-				</li>
-				<li>		
 					<label>
 						<a class="trigger nochild" data-control="setFontSize">
 							{{~ localize "MOBLOKS5E.font-size.label" }}{{ localize "MOBLOKS5E.Colon" ~}}
@@ -207,13 +151,12 @@
 			<ul>
 			{{#each themes as |theme id|}}
 			{{#unless (eq id "custom")}}
-				<li>
-					<a	class="trigger{{#if (eq @root.flags.theme-choice id)}} selected{{/if}}"
-						data-control="pickTheme" 
-						data-value="{{id}}">
-						{{~ localize theme.name ~}}
-					</a>
-				</li>
+				{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
+					control="pickTheme"
+					value=id
+					selected=(eq @root.flags.theme-choice id)
+					title=theme.name
+				}}
 			{{/unless}}
 			{{/each}}
 				<li>


### PR DESCRIPTION
Resolves #158 Convert all switches to the new partial 

- all toggle switches use `switch.hbs` partial
- new `trigger.hbs` partial added and used where appropriate
- reordered Hide / Show Attack and Spellcasting Description underneath Description flyout with other options
   - these were the only two cases of switches having sub items, when in reality to match the formatting of secrets and inline text, they should have likely been included in the sub menu anyway