### PR TITLE
removed redundant moblok-equals helper

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1209,9 +1209,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
-		},
-		"moblok-equals": (val, compare) => {
-			return val === compare;
 		}
 	};
 

--- a/templates/dnd5e/parts/header/attributes/damage.hbs
+++ b/templates/dnd5e/parts/header/attributes/damage.hbs
@@ -4,15 +4,15 @@
 			<h4 class="attribute-name">{{localize label}}</h4>
 			<ul class="traits-list inline-list no-caps">
 				{{~#each damage as |v k|~}}
-					{{~#unless (moblok-equals k "physical")~}}
+					{{~#unless (eq k "physical")~}}
 						<li class="trait-value">{{v}}</li>
 					{{~/unless~}}
 				{{~/each~}}
 			</ul>
 			{{~#each damage as |v k|~}}
-				{{~#if (moblok-equals k "physical")~}}
+				{{~#if (eq k "physical")~}}
 					<span>
-						{{~#unless (moblok-equals @index 0)~}}{{ localize "MOBLOKS5E.SemiColon"}}{{/unless}}
+						{{~#if @index~}}{{ localize "MOBLOKS5E.SemiColon"}}{{/if}}
 						{{v}}
 					</span>
 				{{~/if~}}


### PR DESCRIPTION
I realized that when I did the ordering of physical damage, I created a handlebars helper that was "technically" already there.
This PR removes the redundant `moblok-equals` helper, and replaces where it was used with the built in `eq` helper.