### PR TITLE
Enhanced Lookups

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -80,8 +80,8 @@
 			}
 		},
 		"hide-profile-image": {
-			"enable": "Show profile image",
-			"disable": "Hide profile image",
+			"enable": "Hide profile image",
+			"disable": "Show profile image",
 			"settings": {
 				"name": "Hide Image",
 				"hint": "By default, don't show the creature's image on the sheet (more accurate)."

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -80,8 +80,8 @@
 			}
 		},
 		"hide-profile-image": {
-			"enable": "Afficher image de profil",
-			"disable": "Cacher image de profil",
+			"enable": "Cacher image de profil",
+			"disable": "Afficher image de profil",
 			"settings": {
 				"name": "Cacher l'image",
 				"hint": "Cache l'image de profil de la fiche par défaut"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -80,8 +80,8 @@
 			}
 		},
 		"hide-profile-image": {
-			"enable": "画像を表示",
-			"disable": "画像を非表示",
+			"enable": "画像を非表示",
+			"disable": "画像を表示",
 			"settings": {
 				"name": "画像を非表示",
 				"hint": "デフォルトとしてデータブロックにそのモンスターの画像を表示しなくします。"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -80,8 +80,8 @@
 			}
 		},
 		"hide-profile-image": {
-			"enable": "Mostrar Imagem do Perfil",
-			"disable": "Esconder Imagem do Perfil",
+			"enable": "Esconder Imagem do Perfil",
+			"disable": "Mostrar Imagem do Perfil",
 			"settings": {
 				"name": "Esconder Imagens",
 				"hint": "Por padrão, não mostrar a imagem da criatura na ficha (mais próximo da versão do livro)."

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1210,26 +1210,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
 		},
-		"moblok-concat": (...args) => {
-			args = [...args].slice(0, -1);
-			return [...args].join('');
-		},
-		"moblok-lookupval": (obj, str) => {
-			if (!obj || !str) return;
-
-			str = str.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
-			str = str.replace(/^\./, '');           // strip a leading dot
-			var props = str.split('.');
-			for (var i = 0, n = props.length; i < n; ++i) {
-				var p = props[i];
-				if (p in obj) {
-					obj = obj[p];
-				} else {
-					return;
-				}
-			}
-			return obj;
-		}
+		"moblok-concat": (...args) => args.slice(0, -1).join("")
 	};
 
 	static async preLoadTemplates() {

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -89,6 +89,8 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			data.allFlags.push(flag);
 		}
 
+		data.switches = this.getSwitches(data);
+
 		if (data.notOwner || !this.options.editable) data.flags.editing = false;
 		if (!data.flags.editing) data.flags["show-delete"] = false;
 		if (this.actor.limited) data.flags["show-bio"] = true;
@@ -634,6 +636,28 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		await that.object.setFlag("core", "sheetClass", sheetClass);
 
 		return that.object.sheet.render(true)
+	}
+
+	getSwitches(data) {
+		const switches = {};
+
+		for (let flag of data.allFlags) {
+			let s = {
+				enable: `MOBLOKS5E.${flag.name}.enable`,
+				disable: `MOBLOKS5E.${flag.name}.disable`
+			}
+
+			let enable = game.i18n.localize(s.enable);
+			let disable = game.i18n.localize(s.disable);
+
+			if (s.enable != enable || s.disable != disable) {
+				s.enable = enable;
+				s.disable = disable;
+				switches[flag.name] = s;
+			}
+		}
+
+		return switches;
 	}
 
 	static async getQuickInserts() {
@@ -1209,8 +1233,7 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
-		},
-		"moblok-concat": (...args) => args.slice(0, -1).join("")
+		}
 	};
 
 	static async preLoadTemplates() {

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -443,7 +443,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	}
 	async resetDefaults() {
 		await this.setCurrentTheme(game.settings.get("monsterblock", "default-theme"));
-		console.log(this.defaultFlags);
 		this.actor.update({"flags.monsterblock": this.defaultFlags});
 	}
 	static prop = "A String";

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1209,6 +1209,26 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		},
 		"moblok-enrichhtml": (str, owner, flags) => { // Formats any text to include proper inline rolls and links.
 			return TextEditor.enrichHTML(str || "", { secrets: (owner && !flags["hidden-secrets"]) });
+		},
+		"moblok-concat": (...args) => {
+			args = [...args].slice(0, -1);
+			return [...args].join('');
+		},
+		"moblok-lookupval": (obj, str) => {
+			if (!obj || !str) return;
+
+			str = str.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
+			str = str.replace(/^\./, '');           // strip a leading dot
+			var props = str.split('.');
+			for (var i = 0, n = props.length; i < n; ++i) {
+				var p = props[i];
+				if (p in obj) {
+					obj = obj[p];
+				} else {
+					return;
+				}
+			}
+			return obj;
 		}
 	};
 

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -638,25 +638,12 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 	}
 
 	getSwitches(data) {
-		const switches = {};
-
-		for (let flag of data.allFlags) {
-			let s = {
-				enable: `MOBLOKS5E.${flag.name}.enable`,
-				disable: `MOBLOKS5E.${flag.name}.disable`
-			}
-
-			let enable = game.i18n.localize(s.enable);
-			let disable = game.i18n.localize(s.disable);
-
-			if (s.enable != enable || s.disable != disable) {
-				s.enable = enable;
-				s.disable = disable;
-				switches[flag.name] = s;
-			}
-		}
-
-		return switches;
+		return Object.fromEntries(
+			Object.entries(data.allFlags).map(([k,f]) => [f.name, {
+					enable: game.i18n.localize(`MOBLOKS5E.${f.name}.enable`),
+					disable: game.i18n.localize(`MOBLOKS5E.${f.name}.disable`)
+			}])
+		);
 	}
 
 	static async getQuickInserts() {

--- a/templates/dnd5e/parts/featureBlock.hbs
+++ b/templates/dnd5e/parts/featureBlock.hbs
@@ -1,4 +1,4 @@
-<section class="item monster-feature{{#if legendaryactions}} legendary-actions{{/if}}{{#if lairactions}} lair-actions{{/if}}{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
+<section class="item monster-feature{{#if legendaryactions}} legendary-actions{{/if}}{{#if lairactions}} lair-actions{{/if}}{{#unless item.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
 	<div class="feature-description inline-children">
 		{{#if flags.show-delete}}
 			<a class="delete-item" data-item-id="{{item._id}}">

--- a/templates/dnd5e/parts/main/legendaryActs.hbs
+++ b/templates/dnd5e/parts/main/legendaryActs.hbs
@@ -1,7 +1,6 @@
 {{#> "modules/monsterblock/templates/dnd5e/collapsibleSection.hbs"
 	title="DND5E.LegAct"
 	section="legendary"
-	resource=data.resources.legact
 	resource-key="data.resources.legact"}}
 	<p class="legendary-description">
 		{{ localize "MOBLOKS5E.LegendaryText" name=actor.name number=data.resources.legact.max}}

--- a/templates/dnd5e/parts/main/spellcasting.hbs
+++ b/templates/dnd5e/parts/main/spellcasting.hbs
@@ -1,4 +1,4 @@
-<section class="item monster-feature spellcasting-trait{{#unless casting.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if  @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
+<section class="item monster-feature spellcasting-trait{{#unless casting.flags.monsterblock.expanded}} compact{{/unless}}" title="{{#if @root.flags.editing}}{{ localize 'MOBLOKS5E.EditHint' }}{{/if}}">
 	<div class="feature-description inline-children">
 		{{#if @root.flags.show-delete}}
 			<a class="delete-item" data-item-id="{{casting._id}}">

--- a/templates/dnd5e/parts/switch.hbs
+++ b/templates/dnd5e/parts/switch.hbs
@@ -1,9 +1,9 @@
 <li>
 	<a class="switch" data-control="{{control}}">
 		{{~#if (lookup flags control)}}
-			{{~ localize (moblok-concat "MOBLOKS5E." control ".disable") ~}}
+			{{~ lookup (lookup switches control) "disable" ~}}
 		{{~else}}
-			{{~ localize (moblok-concat "MOBLOKS5E." control ".enable") ~}}
+			{{~ lookup (lookup switches control) "enable" ~}}
 		{{~/if~}}
 	</a>
 	{{#if @partial-block}}

--- a/templates/dnd5e/parts/switch.hbs
+++ b/templates/dnd5e/parts/switch.hbs
@@ -1,9 +1,9 @@
 <li>
 	<a class="switch" data-control="{{control}}">
-		{{~#if flag}}
-			{{~ localize on ~}}
+		{{~#if (lookup flags control)}}
+			{{~ localize (moblok-concat "MOBLOKS5E." control ".disable") ~}}
 		{{~else}}
-			{{~ localize off ~}}
+			{{~ localize (moblok-concat "MOBLOKS5E." control ".enable") ~}}
 		{{~/if~}}
 	</a>
 	{{#if @partial-block}}

--- a/templates/dnd5e/sectionHeader.hbs
+++ b/templates/dnd5e/sectionHeader.hbs
@@ -7,14 +7,14 @@
                 contenteditable="{{@root.owner}}"
                 data-dtype="Number"
                 data-field-key="{{resource-key}}.value">
-                {{~getProperty @root (moblok-concat resource-key ".value")~}}
+                {{~lookup (getProperty @root resource-key) "value"~}}
             </span> /
             <span class="resource-value"
                 placeholder="0"
                 contenteditable="{{@root.flags.editing}}"
                 data-dtype="Number"
                 data-field-key="{{resource-key}}.max">
-                {{~getProperty @root (moblok-concat resource-key ".max")~}}
+                {{~lookup (getProperty @root resource-key) "max"~}}
             </span>
         </span>
     {{/if}}

--- a/templates/dnd5e/sectionHeader.hbs
+++ b/templates/dnd5e/sectionHeader.hbs
@@ -1,20 +1,20 @@
 <h2 class="section-header{{#unless flags.show-collapsible}}{{#if hide-title}} hidden{{/if}}{{/unless}}">
     <span class="title">{{localize title}}</span>
-    {{#if (and flags.show-resources (moblok-lookupval @root (moblok-concat resource-key ".max")))}}
+    {{#if (and flags.show-resources resource-key)}}
         <span class="header-resource">
             <span class="resource-value"
                 placeholder="0"
                 contenteditable="{{@root.owner}}"
                 data-dtype="Number"
                 data-field-key="{{resource-key}}.value">
-                {{~moblok-lookupval @root (moblok-concat resource-key ".value")~}}
+                {{~getProperty @root (moblok-concat resource-key ".value")~}}
             </span> /
             <span class="resource-value"
                 placeholder="0"
                 contenteditable="{{@root.flags.editing}}"
                 data-dtype="Number"
                 data-field-key="{{resource-key}}.max">
-                {{~moblok-lookupval @root (moblok-concat resource-key ".max")~}}
+                {{~getProperty @root (moblok-concat resource-key ".max")~}}
             </span>
         </span>
     {{/if}}

--- a/templates/dnd5e/sectionHeader.hbs
+++ b/templates/dnd5e/sectionHeader.hbs
@@ -1,20 +1,20 @@
 <h2 class="section-header{{#unless flags.show-collapsible}}{{#if hide-title}} hidden{{/if}}{{/unless}}">
     <span class="title">{{localize title}}</span>
-    {{#if (and flags.show-resources resource.max)}}
+    {{#if (and flags.show-resources (moblok-lookupval @root (moblok-concat resource-key ".max")))}}
         <span class="header-resource">
             <span class="resource-value"
                 placeholder="0"
                 contenteditable="{{@root.owner}}"
                 data-dtype="Number"
                 data-field-key="{{resource-key}}.value">
-                {{~resource.value~}}
+                {{~moblok-lookupval @root (moblok-concat resource-key ".value")~}}
             </span> /
             <span class="resource-value"
                 placeholder="0"
                 contenteditable="{{@root.flags.editing}}"
                 data-dtype="Number"
                 data-field-key="{{resource-key}}.max">
-                {{~resource.max~}}
+                {{~moblok-lookupval @root (moblok-concat resource-key ".max")~}}
             </span>
         </span>
     {{/if}}

--- a/templates/dnd5e/switches.hbs
+++ b/templates/dnd5e/switches.hbs
@@ -5,106 +5,36 @@
 			control="switchToDefault"
 			title="MOBLOKS5E.SwitchToDefault"
 		}}
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-			flag=flags.editing 
-			control="editing" 
-			on="MOBLOKS5E.editing.disable" 
-			off="MOBLOKS5E.editing.enable"
-		}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="editing" }}
 		{{#if flags.editing}}
-			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-				flag=flags.show-delete
-				control="show-delete" 
-				on="MOBLOKS5E.show-delete.disable" 
-				off="MOBLOKS5E.show-delete.enable"
-			}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-delete" }}
 		{{/if}}
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-			flag=flags.show-resources
-			control="show-resources" 
-			on="MOBLOKS5E.show-resources.disable" 
-			off="MOBLOKS5E.show-resources.enable"
-		}}
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-			flag=flags.show-skill-save
-			control="show-skill-save" 
-			on="MOBLOKS5E.show-skill-save.disable" 
-			off="MOBLOKS5E.show-skill-save.enable"
-		}}
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-			flag=flags.show-not-prof
-			control="show-not-prof" 
-			on="MOBLOKS5E.show-not-prof.disable" 
-			off="MOBLOKS5E.show-not-prof.enable"
-		}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-resources" }}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-skill-save" }}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-not-prof" }}
 		<li>
 			<a>{{ localize "MOBLOKS5E.DescriptionS" }}</a>
 			<ul>
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
-					flag=flags.attack-descriptions
-					control="attack-descriptions"
-					on="MOBLOKS5E.attack-descriptions.disable"
-					off="MOBLOKS5E.attack-descriptions.enable"
-				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="attack-descriptions" }}
 				{{#if info.hasCastingFeature}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.casting-feature
-					control="casting-feature" 
-					on="MOBLOKS5E.casting-feature.disable" 
-					off="MOBLOKS5E.casting-feature.enable"
-				}}
+					{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="casting-feature" }}
 				{{/if}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.inline-secrets
-					control="inline-secrets" 
-					on="MOBLOKS5E.inline-secrets.disable" 
-					off="MOBLOKS5E.inline-secrets.enable"
-				}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.hidden-secrets
-					control="hidden-secrets" 
-					on="MOBLOKS5E.hidden-secrets.disable" 
-					off="MOBLOKS5E.hidden-secrets.enable"
-				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="inline-secrets" }}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="hidden-secrets" }}
 			</ul>
 		</li>
 		<li>
 			<a>{{ localize "DND5E.HitPoints" }}</a>
 			<ul>
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.current-hit-points
-					control="current-hit-points" 
-					on="MOBLOKS5E.current-hit-points.disable" 
-					off="MOBLOKS5E.current-hit-points.enable"
-				}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.maximum-hit-points
-					control="maximum-hit-points" 
-					on="MOBLOKS5E.maximum-hit-points.disable" 
-					off="MOBLOKS5E.maximum-hit-points.enable"
-				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="current-hit-points" }}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="maximum-hit-points" }}
 			</ul>
 		</li>
 		
-		{{#> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
-			flag=flags.hide-profile-image
-			control="hide-profile-image"
-			on="MOBLOKS5E.ProfileImage"
-			off="MOBLOKS5E.ProfileImage"
-		}}
+		{{#> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="hide-profile-image" }}
 			<ul>
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
-					flag=flags.hide-profile-image
-					control="hide-profile-image"
-					on="MOBLOKS5E.hide-profile-image.disable"
-					off="MOBLOKS5E.hide-profile-image.enable"
-				}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
-					flag=flags.use-token-image
-					control="use-token-image"
-					on="MOBLOKS5E.use-token-image.disable"
-					off="MOBLOKS5E.use-token-image.enable"
-				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="hide-profile-image" }}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="use-token-image" }}
 				{{#if info.vttatokenizer}}
 					{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
 						control="openTokenizer"
@@ -114,19 +44,9 @@
 			</ul>
 		{{/"modules/monsterblock/templates/dnd5e/parts/switch.hbs"}}
 		{{#if info.hasLair}}
-			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-				flag=flags.show-lair-actions
-				control="show-lair-actions" 
-				on="MOBLOKS5E.show-lair-actions.disable" 
-				off="MOBLOKS5E.show-lair-actions.enable"
-			}}
+			{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-lair-actions" }}
 		{{/if}}
-		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-			flag=flags.show-bio
-			control="show-bio" 
-			on="MOBLOKS5E.show-bio.disable" 
-			off="MOBLOKS5E.show-bio.enable"
-		}}
+		{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-bio" }}
 		{{> "modules/monsterblock/templates/dnd5e/parts/trigger.hbs"
 			control="resetDefaults"
 			title="MOBLOKS5E.resetDefaults.label"
@@ -134,30 +54,10 @@
 		<li>
 			<a>{{localize "MOBLOKS5E.mini-block.label"}}</a>
 			<ul>
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs"
-					flag=flags.show-collapsible
-					control="show-collapsible"
-					on="MOBLOKS5E.show-collapsible.disable"
-					off="MOBLOKS5E.show-collapsible.enable"
-				}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.compact-window
-					control="compact-window" 
-					on="MOBLOKS5E.compact-window.disable" 
-					off="MOBLOKS5E.compact-window.enable"
-				}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.compact-layout
-					control="compact-layout" 
-					on="MOBLOKS5E.compact-layout.disable" 
-					off="MOBLOKS5E.compact-layout.enable"
-				}}
-				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" 
-					flag=flags.compact-feats
-					control="compact-feats" 
-					on="MOBLOKS5E.compact-feats.disable" 
-					off="MOBLOKS5E.compact-feats.enable"
-				}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="show-collapsible" }}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="compact-window" }}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="compact-layout" }}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="compact-feats" }}
 				<li>
 					<label>
 						<a class="trigger nochild" data-control="setFontSize">


### PR DESCRIPTION
- Added `moblok-concat` handlebars helper
   - Allows concatenation of strings
- `switch.hbs`
   - now only needs a `data-control` value
   - Uses `getProperty` to get the `flag` condition, and uses `moblok-concat` to generate the localization string
- `switches.hbs`
   - Significantly simplified because of the changes to `switch.hbs`
- `sectionHeader.hbs`
   - now only needs, or must provide, a `value / max` property for its `resource-key` value
   - Visibility of the resource is now defined if a `resource-key` has been provided
   - The `value` and `max` values are looked up using `getProperty` and `moblok-concat` helpers
- `collapsibleSection.hbs`
   - Now only requires `resource-key` to provide access to the header resource value
- reversed the language of `hide-profile-image`, not sure if this was incorrect before, but it was incorrect after these changes

I am certain there are a lot of other places where these two helpers could become quite useful, but these were the two really obvious places that I have been touching.