### PR TITLE
Changed Recharge

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -233,8 +233,6 @@
 		"AddInventory": "Loot",
 		"AddConsumable": "Consumable",
 		
-		"Recharge": "Recharge",
-		"NCharged": "Not charged",
 		"Costs": "Costs",
 		"ResourceRefresh": "Day",
 		

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -233,8 +233,6 @@
 		"AddInventory": "Trésor",
 		"AddConsumable": "Consommable",
 		
-		"Recharge": "Recharge",
-		"NCharged": "Pas chargé",
 		"Costs": "Coûts",
 		"ResourceRefresh": "Jour",
 		

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -233,8 +233,6 @@
 		"AddInventory": "戦利品",
 		"AddConsumable": "消耗品",
 
-		"Recharge": "再チャージ",
-		"NCharged": "チャージ失敗",
 		"Costs": "コスト",
 		"ResourceRefresh": "日",
 

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -233,8 +233,6 @@
 		"AddInventory": "Inventário",
 		"AddConsumable": "Consumível",
 
-		"Recharge": "Recarga",
-		"NCharged": "Não carregada",
 		"Costs": "Custa",
 		"ResourceRefresh": "Dia",
 

--- a/monsterblock.css
+++ b/monsterblock.css
@@ -238,13 +238,13 @@
 }
 .monsterblock .item-attackRoll:hover,
 .monsterblock .item-damageRoll:hover,
+.monsterblock .item-recharge:hover,
 .monsterblock .ability:hover, 
 .monsterblock .saving-throw:hover, 
 .monsterblock .skill:hover, 
 .monsterblock .item-name:hover, 
 .monsterblock .spell:hover, 
 .monsterblock a.inline-roll:hover, 
-.monsterblock [data-roll-formula]:hover, 
 .monsterblock .window-content a:hover, 
 .monsterblock .tweak-menu ul label:hover,
 .monsterblock .menu .menu-toggle:hover {
@@ -1120,4 +1120,7 @@ li:nth-last-of-type(2):after {
 }
 .monsterblock .flavor-text > p {
 	padding: 0 1ch;
+}
+.monsterblock .warn {
+	color: darkred;
 }

--- a/monsterblock.css
+++ b/monsterblock.css
@@ -706,6 +706,9 @@ li:nth-last-of-type(2):after {
 .monsterblock .spell .name-extension {
 	font-weight: initial;
 }
+.monsterblock .item-recharge {
+	color: var(--heading-color);
+}
 .monsterblock .legendary-actions .feature-description {
 	padding-left: 2ch;
 	text-indent: -2ch;
@@ -1120,7 +1123,4 @@ li:nth-last-of-type(2):after {
 }
 .monsterblock .flavor-text > p {
 	padding: 0 1ch;
-}
-.monsterblock .warn {
-	color: darkred;
 }

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -703,42 +703,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 			}).render(true);
 		});
 		
-		html.find("[data-roll-formula]").click(async (event) => {			// Universal way to add an element that provides a roll, just add the data attribute "data-roll-formula" with a formula in it, and this applies.
-			event.preventDefault();									// This handler makes "quick rolls" possible, it just takes some data stored on the HTML element, and rolls dice directly.
-			event.stopPropagation();
-			
-			const formula = event.currentTarget.dataset.rollFormula;
-			const target = event.currentTarget.dataset.rollTarget;
-			const success = event.currentTarget.dataset.rollSuccess;
-			const failure = event.currentTarget.dataset.rollFailure;
-			const handler = event.currentTarget.dataset.rollHandler;
-			let flavor = event.currentTarget.dataset.rollFlavor;	// Optionally, you can include data-roll-flavor to add text to the message.
-			
-			let roll;
-			try { 
-				roll = new Roll(formula);
-				await roll.roll({ async: true }); 
-			}
-			catch (e) {
-				console.error(e);
-				ui.notifications.error(e);
-				roll = new Roll("0");
-				await roll.roll({ async: true });
-			}
-			
-			if (target) {
-				let s = roll.total >= parseInt(target, 10);
-				if (handler) this[handler](s, event); 
-				
-				flavor += `<span style="font-weight: bold; color: ${s ? "green" : "red"};">${s ? success : failure}</span>`;
-			}
-			
-			roll.toMessage({					// Creates a new Roll, rolls it, and sends the result as a message
-				flavor: flavor,										// Including the text as defined
-				speaker: ChatMessage.getSpeaker({actor: this.actor})// And setting the speaker to the actor this sheet represents
-			});
-		});
-		
 		// Special Roll Handlers
 		html.find(".ability").click(async (event) => {
 			event.preventDefault();
@@ -772,6 +736,13 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 				window.BetterRolls.rollItem(item, { event, preset }).toMessage();
 			}
 			else return item.roll(); // Conveniently, items have all this logic built in already.
+		});
+
+		html.find(".item-recharge").click(async (event) => {
+			event.preventDefault();
+
+			const item = this.actor.items.get(event.currentTarget.dataset.itemId);
+			item.rollRecharge();
 		});
 
 		// uses the built in attack roll from the item

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1112,22 +1112,6 @@ export default class MonsterBlock5e extends ActorSheet5eNPC {
 		await this.render(true);
 	}
 
-	/**
-	 *
-	 *
-	 * @param {boolean} success - Whether or not the roll was a success.
-	 * @param {Event} event - The event object associated with this roll.
-	 * @memberof MonsterBlock5e
-	 */
-	async setCharged(success, event) {
-		await this.actor.updateEmbeddedDocuments("Item", [{
-			_id: event.currentTarget.dataset.itemId,
-			"data.recharge.charged": success
-		}])
-
-		super._onChangeInput(event);
-	}
-
 	static isMultiAttack(item) {	// Checks if the item is the multiattack action.
 		let name = item.name.toLowerCase().replace(/\s+/g, "");	// Convert the name of the item to all lower case, and remove whitespace.
 		return getTranslationArray("MOBLOKS5E.MultiattackLocators").some(loc => name.includes(loc));

--- a/templates/dnd5e/parts/featureBlock.hbs
+++ b/templates/dnd5e/parts/featureBlock.hbs
@@ -10,8 +10,8 @@
 				{{~item.name~}} 
 			</span>
 			{{~#if item.data.recharge.value~}}
-				<span class="name-extension{{#unless item.data.recharge.charged}} item-recharge warn{{/unless}}" data-item-id="{{item._id}}">
-					({{#if item.data.recharge.charged}}{{localize "DND5E.Charged"}}{{else}}{{localize "DND5E.Recharge"}}{{/if}} {{item.data.recharge.value}}-6){{~" "~}}
+				<span class="name-extension{{#unless item.data.recharge.charged}} item-recharge{{/unless}}" data-item-id="{{item._id}}">
+					({{localize "DND5E.Recharge"}} {{item.data.recharge.value}}-6){{~" "~}}
 				</span>
 			{{~/if~}}
 			{{~#if (and item.is.legendary (gt item.data.activation.cost 1))~}}

--- a/templates/dnd5e/parts/featureBlock.hbs
+++ b/templates/dnd5e/parts/featureBlock.hbs
@@ -10,15 +10,8 @@
 				{{~item.name~}} 
 			</span>
 			{{~#if item.data.recharge.value~}}
-				<span class="name-extension"
-					data-item-id="{{item._id}}"
-					data-roll-flavor="{{item.name}} ({{localize "MOBLOKS5E.Recharge"}} {{item.data.recharge.value}}-6): " 
-					data-roll-formula="1d6" 
-					data-roll-target="{{item.data.recharge.value}}" 
-					data-roll-success="{{localize "DND5E.Charged"}}" 
-					data-roll-failure="{{localize "MOBLOKS5E.NCharged"}}"
-					data-roll-handler="setCharged">
-					({{localize "MOBLOKS5E.Recharge"}} {{item.data.recharge.value}}-6){{~" "~}}
+				<span class="name-extension{{#unless item.data.recharge.charged}} item-recharge warn{{/unless}}" data-item-id="{{item._id}}">
+					({{#if item.data.recharge.charged}}{{localize "DND5E.Charged"}}{{else}}{{localize "DND5E.Recharge"}}{{/if}} {{item.data.recharge.value}}-6){{~" "~}}
 				</span>
 			{{~/if~}}
 			{{~#if (and item.is.legendary (gt item.data.activation.cost 1))~}}


### PR DESCRIPTION
This PR introduces changes to Recharge that I have incorporated in my local branch. I thought I would share them here to see if there is any interest. If not interested in these changed, feel free to close the PR.

- Changes the appearance of how Recharge works on the sheet
   - When the item is not charged, the text Recharge (_n_-6) appears in red letting the user know the item is not charged
   - When the user clicks Recharge, the NPC rolls the recharge
   - When the item is charged, the text Charged (_n_-6) appears in standard text format
   - When the item is charged, the text for recharge does not roll, or change format when hovering (the built in roll does not change the value when rolling recharge when the item is already charged)
- Uses the DND5E built in recharge roll
   - I will say, I did like the colors in the chat card with the previous roll, however...
   - Built in recharge roll is `async` and waits until the roll is completed for mods like DiceSoNice to produce results after the roll is completed
   - Ensures any other mods that may leverage `rollRecharge` can still do so
   - Eliminates the needs for `html.find("[data-roll-formula]").click`, which appears to be solely used for item recharge
   - Eliminates the need for complex parameters for recharge roll in `featureBlock.hbs`
- Reduces the localization requirements
   - Uses DND5E localization strings for `Charged` and `Recharge`
   - Removes the need for `NCharged` localization string

https://user-images.githubusercontent.com/7407481/158609275-69d2c10e-b9c2-4510-a871-7859cef4b4c8.mp4