### PR TITLE
Issue #63 Added Temp HP

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -119,6 +119,14 @@
 				"hint": "By default, display the current hit point in the hit points field. If neither maximum nor minimum Hit Points are shown, the average will be calculated and displayed."
 			}
 		},
+		"temp-hit-points": {
+			"enable": "Show temporary hit points",
+			"disable": "Hide temporary hit points",
+			"settings": {
+				"name": "Show Temporary Hit Points",
+				"hint": "By default, display the temporary hit point values underneith the current it point values."
+			}
+		},
 		"max-height-offset": {
 			"settings": {
 				"name": "Maximum Height Offset",
@@ -199,8 +207,6 @@
 		"SystemThemeName": "5e System",
 		
 		"Average": "Average",
-		"Current": "Current",
-		"Maximum": "Maximum",
 		
 		"Abbrstr": "str",
 		"Abbrdex": "dex",

--- a/lang/en.json
+++ b/lang/en.json
@@ -124,7 +124,7 @@
 			"disable": "Hide temporary hit points",
 			"settings": {
 				"name": "Show Temporary Hit Points",
-				"hint": "By default, display the temporary hit point values underneith the current it point values."
+				"hint": "By default, display the temporary hit point values after the current it point values."
 			}
 		},
 		"max-height-offset": {
@@ -206,7 +206,7 @@
 		"FoundryThemeName": "Foundry",
 		"SystemThemeName": "5e System",
 		
-		"Average": "Average",
+		"Average": "Average Hit Points",
 		
 		"Abbrstr": "str",
 		"Abbrdex": "dex",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -119,6 +119,14 @@
 				"hint": "Affiche le maximum de points de vie par défaut."
 			}
 		},
+		"temp-hit-points": {
+			"enable": "Afficher les points de vie temporaires",
+			"disable": "Masquer les points de vie temporaires",
+			"settings": {
+				"name": "Afficher les points de vie temporaires",
+				"hint": "Par défaut, affichez les valeurs des points de vie temporaires après les valeurs actuelles des points it."
+			}
+		},
 		"max-height-offset": {
 			"settings": {
 				"name": "Décalage de hauteur maximale",
@@ -198,9 +206,7 @@
 		"FoundryThemeName": "Foundry",
 		"SystemThemeName": "5e System",
 		
-		"Average": "Moyen",
-		"Current": "Actuel",
-		"Maximum": "Maximum",
+		"Average": "Points de vie moyens",
 		
 		"Abbrstr": "for",
 		"Abbrdex": "dex",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -119,6 +119,14 @@
 				"hint": "最大ヒットポイントを計算して表示します。最大と最低HPが表示されていない場合は平均を使用します。"
 			}
 		},
+		"temp-hit-points": {
+			"enable": "一時的なヒットポイントを表示する",
+			"disable": "一時的なヒットポイントを非表示にする",
+			"settings": {
+				"name": "一時的なヒットポイントを表示する",
+				"hint": "デフォルトでは、現在のitポイント値の後に一時的なヒットポイント値を表示します。"
+			}
+		},
 		"max-height-offset": {
 			"settings": {
 				"name": "ウィンドウの最大の長さオフセット",
@@ -198,9 +206,7 @@
 		"FoundryThemeName": "Foundry",
 		"SystemThemeName": "5e System",
 
-		"Average": "平均",
-		"Current": "現在",
-		"Maximum": "最大",
+		"Average": "平均ヒットポイント",
 
 		"Abbrstr": "【筋】",
 		"Abbrdex": "【敏】",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -119,6 +119,14 @@
 				"hint": "Por padrão, mostrar o máximo de Pontos de Vida no campo Pontos de Vida."
 			}
 		},
+		"temp-hit-points": {
+			"enable": "Mostrar pontos de vida temporários",
+			"disable": "Ocultar pontos de vida temporários",
+			"settings": {
+				"name": "Mostrar pontos de vida temporários",
+				"hint": "Por padrão, exibe os valores temporários dos pontos de vida após os valores atuais dos pontos it."
+			}
+		},
 		"max-height-offset": {
 			"settings": {
 				"name": "Compensação da Altura Máxima",
@@ -198,9 +206,7 @@
 		"FoundryThemeName": "Foundry",
 		"SystemThemeName": "5e System",
 
-		"Average": "Média",
-		"Current": "Atual",
-		"Maximum": "Máximo",
+		"Average": "Pontos de vida médios",
 
 		"Abbrstr": "for",
 		"Abbrdex": "des",

--- a/scripts/dnd5e/Flags5e.js
+++ b/scripts/dnd5e/Flags5e.js
@@ -14,6 +14,7 @@ export default class Flags5e extends Flags {
 			"casting-feature"    : { type: Boolean, default: true  },
 			"current-hit-points" : { type: Boolean, default: true  },
 			"maximum-hit-points" : { type: Boolean, default: true  },
+			"temp-hit-points"    : { type: Boolean, default: false },
 			"show-lair-actions"  : { type: Boolean, default: false },
 			"show-not-prof"      : { type: Boolean, default: false },
 			"show-resources"     : { type: Boolean, default: true  },

--- a/templates/dnd5e/parts/header/attributes/hitpoints.hbs
+++ b/templates/dnd5e/parts/header/attributes/hitpoints.hbs
@@ -7,7 +7,7 @@
 	<span title="{{localize "MOBLOKS5E.Average"}}" class="attr-value">{{data.attributes.hp.average}}</span>
 {{~/unless~}}
 {{#if flags.current-hit-points}}
-	<span title="{{localize "MOBLOKS5E.Current"}}" 
+	<span title="{{localize "DND5E.HitPointsCurrent"}}" 
 		placeholder="0" 
 		data-field-key="data.attributes.hp.value" 
 		data-dtype="Number" 
@@ -20,11 +20,27 @@
 		{{~/if~}}
 	</span>
 {{~/if~}}
+{{#if flags.temp-hit-points}}
+	<span class="paren">(</span>{{~" "~}}
+	<span title="{{~localize "DND5E.HitPointsTemp"~}}" 
+		placeholder="0" 
+		data-field-key="data.attributes.hp.temp" 
+		data-dtype="Number" 
+		class="attr-value" 
+		contenteditable="{{owner}}">
+		{{~#if data.attributes.hp.temp~}}
+			{{~data.attributes.hp.temp~}}
+		{{~else~}}
+			0
+		{{~/if~}}
+	</span>{{~" "~}}
+	<span class="paren">)</span>
+{{/if}}
 {{~#if (and flags.current-hit-points flags.maximum-hit-points)~}}
 	<span class="sep"> / </span>
 {{~/if~}}
 {{~#if flags.maximum-hit-points~}}
-	<span title="{{localize "MOBLOKS5E.Maximum"}}" 
+	<span title="{{localize "DND5E.HitPointsMax"}}" 
 		placeholder="0" 
 		data-field-key="data.attributes.hp.max" 
 		data-dtype="Number"
@@ -36,6 +52,10 @@
 			0
 		{{~/if~}}
 	</span>
+{{/if}}
+
+{{#if flags.temp-hit-points}}
+
 {{/if}}
 
 {{#if data.attributes.hp.formula}}<span class="paren">(</span>{{~/if~}}

--- a/templates/dnd5e/parts/header/attributes/hitpoints.hbs
+++ b/templates/dnd5e/parts/header/attributes/hitpoints.hbs
@@ -45,7 +45,7 @@
 		data-field-key="data.attributes.hp.max" 
 		data-dtype="Number"
 		class="attr-value" 
-		contenteditable="{{owner}}">
+		contenteditable="{{flags.editing}}">
 		{{~#if data.attributes.hp.max~}}
 			{{data.attributes.hp.max~}}
 		{{~else~}}
@@ -53,11 +53,6 @@
 		{{~/if~}}
 	</span>
 {{/if}}
-
-{{#if flags.temp-hit-points}}
-
-{{/if}}
-
 {{#if data.attributes.hp.formula}}<span class="paren">(</span>{{~/if~}}
 <span title="Average: {{data.attributes.hp.average}}"
 	placeholder="(1d6)"

--- a/templates/dnd5e/switches.hbs
+++ b/templates/dnd5e/switches.hbs
@@ -28,6 +28,7 @@
 			<ul>
 				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="current-hit-points"}}
 				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="maximum-hit-points"}}
+				{{> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="temp-hit-points"}}
 			</ul>
 		</li>
 		{{#> "modules/monsterblock/templates/dnd5e/parts/switch.hbs" control="hide-profile-image"}}


### PR DESCRIPTION
This PR closes #184 Add Temp HP

- This PR does not add Max Temp HP. I haven't actually found a place where max temp hp is used
- This currently has a module level option to enable this. I could see this being set to hidden and toggled on per actor
- The Temp HP appears in parenthesis behind the current HP on the NPC
- This PR changed the tooltips to use the build in DND5E tooltips for Temp HP
- This PR changes the language of Average to Average Hit Points for consistency with the DND5E system's language