### PR TITLE
fixes comma spacing after hover text

### DIFF
--- a/templates/dnd5e/parts/header/attributes/movement.hbs
+++ b/templates/dnd5e/parts/header/attributes/movement.hbs
@@ -8,7 +8,7 @@
 			<span class="no-break nocaps">
 				<span class="paren">(</span>
 					{{~localize "DND5E.MovementHover"~}}
-				<span class="paren">)</span>
+				<span class="paren">)</span>{{~" "~}}
 			</span>
 		{{~/if~}}
 	</span>


### PR DESCRIPTION
The movment.hbs template is creating a space after the parenthesis when hover is displayed.
![image](https://user-images.githubusercontent.com/7407481/162527903-887d0ec6-5fae-4a18-bc07-3760c95ed8ff.png)
This PR resolves this issue using the `{{~" "~}}` technique
![image](https://user-images.githubusercontent.com/7407481/162527974-d2a54b41-04d5-4cc9-8511-5b474f3ddd2e.png)