### PR TITLE
Resolves #218 Senses show "null" instead of correct unit 

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -612,7 +612,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 				label: game.i18n.localize(`DND5E.Sense${senseNameCaps}`).toLowerCase(),
 				value: sense == "special" ? range : range > 0 ? range : "",
 				unit: (data.system.attributes.senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0]) + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
-				key: `data.attributes.senses.${sense}`
+				key: `system.attributes.senses.${sense}`
 			});
 		}
 

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -574,7 +574,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 			});
 		}
 
-		data.movement = movement;
+		data.movement = movement.filter(m => m.value || m.name == "walk");
 	}
 
 	/**
@@ -617,7 +617,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 		}
 
 		const special = senses.pop();
-		data.senses = senses;
+		data.senses = senses.filter(s => s.value);
 		data.specialSenses = {
 			passivePerception: this.getPassivePerception(),
 			special

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -569,7 +569,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 				showLabel: move != "walk",
 				label: game.i18n.localize(`DND5E.Movement${moveNameCaps}`).toLowerCase(),
 				value: speed > 0 ? speed : move != "walk" ? "" : "0",
-				unit: data.system.attributes.movement.units + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
+				unit: (data.system.attributes.movement.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0]) + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
 				key: `system.attributes.movement.${move}`
 			});
 		}
@@ -611,7 +611,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 				name: sense,
 				label: game.i18n.localize(`DND5E.Sense${senseNameCaps}`).toLowerCase(),
 				value: sense == "special" ? range : range > 0 ? range : "",
-				unit: data.system.attributes.senses.units + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
+				unit: (data.system.attributes.senses.units ?? Object.keys(CONFIG.DND5E.movementUnits)[0]) + game.i18n.localize("MOBLOKS5E.SpeedUnitAbbrEnd"),
 				key: `data.attributes.senses.${sense}`
 			});
 		}

--- a/templates/dnd5e/parts/header/attributes/movement.hbs
+++ b/templates/dnd5e/parts/header/attributes/movement.hbs
@@ -4,7 +4,7 @@
 		{{~#if (and move.value move.showLabel)}}{{move.label}} {{/if~}}
 		{{#if move.value}}{{move.value}}{{/if~}}
 		{{~#if move.value}} {{move.unit}}{{/if~}}
-		{{~#if (and move.fly ../data.attributes.movement.hover)~}}
+		{{~#if (and move.fly ../system.attributes.movement.hover)~}}
 			<span class="no-break nocaps">
 				<span class="paren">(</span>
 					{{~localize "DND5E.MovementHover"~}}

--- a/templates/dnd5e/parts/header/attributes/senses.hbs
+++ b/templates/dnd5e/parts/header/attributes/senses.hbs
@@ -1,38 +1,21 @@
 <h4 class="attribute-name">{{localize "DND5E.Senses"}}</h4>
 {{#each senses as |sense|~}}
-	<span class="editable-wrapper">
+	<span class="editable-wrapper{{#if @index}} optional-comma{{/if}}">
 		{{~#if sense.value}}{{sense.label}} {{/if~}}
-		<span class="attr-value" contenteditable="{{../flags.editing}}" placeholder="{{sense.label}}&nbsp;"
-			data-field-key="{{sense.key}}" data-dtype="Number">
-			{{~sense.value~}}
-		</span>
+		{{#if sense.value}}{{sense.value}}{{/if~}}
 		{{~#if sense.value}} {{sense.unit}}{{/if~}}
 	</span>
-	{{~#if sense.value}}{{localize "MOBLOKS5E.Comma"}} {{/if~}}
 {{~/each~}}
+{{~#if senses.length}}{{localize "MOBLOKS5E.Comma"}} {{/if~}}
+{{~#if specialSenses.special.value~}}
 <span class="editable-wrapper">{{~" "~}}
-	<span class="attr-value" contenteditable="{{flags.editing}}" placeholder="{{specialSenses.special.label}}&nbsp;"
-		data-field-key="{{specialSenses.special.key}}">
-		{{~specialSenses.special.value~}}
-	</span>{{~" "~}}
+	{{~specialSenses.special.value~}}
 </span>
-{{~#if specialSenses.special.value}}{{localize "MOBLOKS5E.Comma"}} {{/if~}}
+{{~localize "MOBLOKS5E.Comma"}}
+{{/if~}}
 <span>
 	{{~specialSenses.passivePerception~}}
 </span>
-{{#if flags.editing~}}
-	<div class="hover-only select-field" data-select-key="system.attributes.senses.units"
-		data-selected-value="{{data.attributes.senses.units}}">
-		<label
-			class="{{#if flags.editing}}select-label{{/if}}">{{lookup config.movementUnits data.attributes.senses.units}}</label>{{~" "~}}
-		{{#if flags.editing~}}
-			<ul class="actor-size select-list">
-			{{#each config.movementUnits as |label unit|}}
-				{{#unless (eq unit ../data.attributes.senses.units)}}
-					<li data-selection-value="{{unit}}">{{label}}</li>
-				{{/unless}}
-			{{~/each~}}
-			</ul>
-		{{~/if~}}
-	</div>
-{{~/if~}}
+<a class="config-button" data-action="senses" title="{{localize " DND5E.SensesConfig"}}">
+	<i class="fas fa-cog"></i>{{~" "~}}
+</a>


### PR DESCRIPTION
Fixes #218. Selecting the "Automatic" unit option under movement or senses caused movement.units to return null. I've resolved it by just using the system's first unit option if the units field is null.