### PR TITLE
Fix several broken references relating to traits and proficiencies.

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -310,7 +310,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 			menu.add(new MenuItem("save-toggle", {
 				name: CONFIG.DND5E.abilities[ab].label,
 				flag, d: ab,
-				target: `data.abilities.${ab}.proficient`,
+				target: `system.abilities.${ab}.proficient`,
 				icon: flag ? '<i class="fas fa-check"></i>' : '<i class="far fa-circle"></i>'
 			}, (m) => {
 				m.flag = Boolean(this.actor.system.abilities[ab]?.proficient);
@@ -327,7 +327,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 			skill.abilityAbbr = game.i18n.localize(`MOBLOKS5E.Abbr${skill.ability}`);
 			skill.icon = this._getProficiencyIcon(skill.value);
 			skill.hover = CONFIG.DND5E.proficiencyLevels[skill.value];
-			skill.label = CONFIG.DND5E.skills[id];
+			skill.label = CONFIG.DND5E.skills[id].label;
 			menu.add(new MenuItem("skill", { id, skill }, (m, data) => {
 				m.skill.icon = data.skills[m.id].icon,
 				m.skill.value = data.skills[m.id].value
@@ -986,7 +986,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 
 		["dv", "dr", "di"].forEach(dg => {
 			let damageTypes = html.find(`[data-damage-type="system.traits.${dg}"]`);
-			let key = `data.traits.${dg}.value`;
+			let key = `system.traits.${dg}.value`;
 			let value = [];
 			for (let dt of damageTypes) {
 				let state = (dt.dataset.flag == "true");

--- a/templates/dnd5e/parts/menuItem.hbs
+++ b/templates/dnd5e/parts/menuItem.hbs
@@ -24,7 +24,7 @@
 					<span class="menu-item-icon">{{{skill.icon}}}</span>{{~" "~}}
 					<span class="skill-label">{{skill.label}}</span>
 					<span class="skill-ability">{{skill.abilityAbbr}}</span>
-					<a class="config-button" data-action="skill" title="Configure Skill"><i class="fas fa-cog"></i></a>
+					<a class="config-button" data-action="skill" title="Configure Skill" data-key={{id}}><i class="fas fa-cog"></i></a>
 				</span>
 			</label>
 		</li>


### PR DESCRIPTION
- Fixes saves, resistances, vulnerabilities and immunities not being able to be toggled by clicking on them due to incorrect references.
- Fixes labels for skills showing as [Object object] due to not referencing the label but the skill object itself.
- Fixes skill configuration panel not opening due to the data key not being present in the html a tag.

Not sure if these were issues only I was experiencing because I don't see any open issues on these topics but the save/skill/damage dropdowns all seemed to have bugs that prevented toggling them, caused incorrect skill labeling, and errors when trying to open skill configuration.

Tested on Version 11 Stable 315, DND System 3.0.3

