### PR TITLE
Fixes #217 Can minimize but not re-open a block

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -391,10 +391,10 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 	 * @memberof MonsterBlock5e
 	 */
 	getTraitChecklist(id, menu, target, itemType, traitList) {
-		Object.entries(traitList).forEach(([d, name]) => {
+		Object.entries(traitList).forEach(([d, traitData]) => {
 			let flag = this.actor.system.traits[id].value.has(d);
 			menu.add(new MenuItem(itemType, {
-				d, name, flag,
+				d, name: traitData.label, flag,
 				target: target,
 				icon: flag ? '<i class="fas fa-check"></i>' : '<i class="far fa-circle"></i>'
 			}, (m) => {

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -344,7 +344,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 	}
 	prepDamageTypeMenu(id, label, attrMenu) {
 		let menu = this.addMenu(id, game.i18n.localize(label), attrMenu);
-		this.getTraitChecklist(id, menu, `system.traits.${id}`, "damage-type", CONFIG.DND5E.damageResistanceTypes);
+		this.getTraitChecklist(id, menu, `system.traits.${id}`, "damage-type", CONFIG.DND5E.damageTypes);
 		return menu;
 	}
 	prepConditionTypeMenu(id, label, attrMenu) {

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1145,12 +1145,6 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 		return super.close(...args);
 	}
 
-	async maximize() {
-		// this led to some sort of infinite resize loops
-		// await super.maximize();
-		await this.render(true);
-	}
-
 	/**
 	 *
 	 *

--- a/templates/dnd5e/parts/header/identity.hbs
+++ b/templates/dnd5e/parts/header/identity.hbs
@@ -1,12 +1,12 @@
 <h1 class="charname" contenteditable="{{flags.editing}}" data-field-key="name" placeholder="{{localize "DND5E.Name"}}">{{actor.name}}</h1>
 <div class="chartype">
 	<div class="select-field" data-select-key="system.traits.size" data-selected-value="{{system.traits.size}}">
-		<label class="{{#if flags.editing}}select-label{{/if}}">{{lookup config.actorSizes system.traits.size}}</label>{{~" "~}}
+		<label class="{{#if flags.editing}}select-label{{/if}}">{{lookup (lookup config.actorSizes system.traits.size) "label"}}</label>{{~" "~}}
 		{{#if flags.editing~}}
 			<ul class="actor-size select-list">
-			{{#each config.actorSizes as |label size|}}
+			{{#each config.actorSizes as |sizeData size|}}
 				{{#unless (eq size ../system.traits.size)}}
-					<li data-selection-value="{{size}}">{{label}}</li>
+					<li data-selection-value="{{size}}">{{sizeData.label}}</li>
 				{{/unless}}
 			{{~/each~}}
 			</ul>


### PR DESCRIPTION
Fixes #217 The super call on maximize was commented out because it was causing an infinite recursive render loop, however this prevented the base maximize from being called at all. Removing the override completely seems to resolve the infinite loop without preventing maximize from being called.