### PR TITLE
Resolves #191 'Show to Players' button when showing actor artwork from MonsterBlocks doesn't load the image

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -705,7 +705,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 		html.find(".profile-image").click((event) => {
 			event.preventDefault();
 
-			new ImagePopout(event.target.currentSrc, {
+			new ImagePopout(this.actor.img, {
 				title: this.actor.name,
 				shareable: true,
 				uuid: this.actor.uuid
@@ -894,6 +894,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 		const entity = this.lastSelection.entity ? `[data-entity="${this.lastSelection.entity}"]` : "";
 		if (key) this.selectElement(html.find(`${key}${entity}`)[0]);
 
+		html.find("img[data-edit]").unbind("click");
 		html.find(".editor-content img").click((event) => {
 			event.preventDefault();
 			let imgSource = event.target.src;


### PR DESCRIPTION
This issue (#191) was caused by event.target.currentSrc (local URL) being used to display the image popout. The result was that foundry attempted to display the image using a localhost url on remote machines when sharing. 

Looking at the code behind the "View Character Artwork" option in the actor directory suggests that actor.img should be used instead, so that's what I went with.

Additionally, I implemented a fix for the issue where the image edit dialog would pop up on left click alongside the image popout. This is done by simply unbinding all click events on the relevant element, which is admittedly not the cleanest solution, but it seems to be working as expected.
