### PR TITLE
Resolves #215 Condition Immunities are not displayed

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -76,6 +76,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 		this.prepMovement(data);
 		this.prepSenses(data);
 		this.updateDamageImmunityResistanceVulnerabilityText(data);
+		this.setupConditionImmunityText(data);
 
 		data.flags = {};
 		data.allFlags = [];
@@ -380,6 +381,14 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 			trait.visible = trait.physical || regularTypes.size > 0;
 		});
 	}
+	
+	setupConditionImmunityText(data)
+	{
+		const trait = data.system.traits["ci"];
+		trait.selected = trait.value;
+		trait.visible = trait.selected.size > 0;
+	}
+
 	/**
 	 * This method creates MenuItems and populates the target menu for trait lists.
 	 *


### PR DESCRIPTION
Fixes #215. The condition immunity display uses the damage.hbs template but didn't set trait.selected or trait.visible anywhere. As a result the condition immunities were never rendered because visible was always false. Resolved by adding a setup function specifically for the condition immunity text. (Alternatively you could add it to the array in `updateDamageImmunityResistanceVulnerabilityText`, but that introduces some redundant lookups.)