### PR TITLE
Support MidiQOL reaction types

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1194,7 +1194,14 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 	}
 
 	static isReaction(item) {
-		return item.system?.activation?.type === "reaction";
+		return [
+			// dnd5e
+			"reaction",
+			// midi-qol
+			"reactionpreattack",
+			"reactiondamage",
+			"reactionmanual",
+		].includes(item.system?.activation?.type);
 	}
 
 


### PR DESCRIPTION
This enables the display of MidiQOL's extra reaction types, which are otherwise missing from the sheet.

See: https://gitlab.com/tposney/midi-qol/-/blob/dnd3/src/midi-qol.ts?ref_type=heads#L376

---

Default sheet:

![image](https://github.com/user-attachments/assets/0483325b-8632-4c20-bfae-45bfa1b2abe8)

Before:

![image](https://github.com/user-attachments/assets/fb4a231b-59c6-4a81-8464-0ca7ea8c0e6c)

After:

![image](https://github.com/user-attachments/assets/4f02c5b4-7bf7-442f-bf22-78bab5a3cac8)
