### PR TITLE
Misc fixes to the most recent issues

### DIFF
--- a/scripts/dnd5e/CastingPreper.js
+++ b/scripts/dnd5e/CastingPreper.js
@@ -43,6 +43,8 @@ export default class CastingPreper extends ItemPreper {
 	 */
 	static isInnateSpellcasting(item) {
 		const name = item.name.toLowerCase().replace(/\s+/g, "") ?? "";
+		if (getTranslationArray("MOBLOKS5E.SpellcastingLocators").some(loc => name.includes(loc)) && item.system.activities?.some(a => a.type === "cast")) return true;
+		
 		return getTranslationArray("MOBLOKS5E.InnateCastingLocators").some(loc => name.includes(loc));
 	}
 	/**
@@ -332,7 +334,7 @@ export default class CastingPreper extends ItemPreper {
 	 * @memberof CastingPreper
 	 */
 	get casterLevel() {
-		return this.sheet.actor.system.details?.spellLevel ?? 0;
+		return this.sheet.actor.system.attributes?.spell?.level ?? this.sheet.actor.system.details?.spellLevel ?? 0;
 	}
 
 	/**
@@ -452,7 +454,7 @@ export default class CastingPreper extends ItemPreper {
 	 */
 	get casterStatsText() {
 		return game.i18n.format("MOBLOKS5E.CastingStats", {
-			savedc: this.sheet.actor.system?.attributes?.spelldc,
+			savedc: this.sheet.actor.system?.attributes?.spell?.dc ?? this.sheet.actor.system?.attributes?.spelldc,
 			bonus: `${this.tohit > -1 ? "+" : ""}${this.tohit}`
 		})
 	}
@@ -557,10 +559,10 @@ export default class CastingPreper extends ItemPreper {
 
 		if (spelllevel !== undefined) {
 			let spell = spelllevel.spells.find((s) =>
-				s.system.ability &&
-				s.system.ability != main
+				s.system.abilityMod &&
+				s.system.abilityMod != main
 			);
-			castingability = spell?.data?.ability ?? main;
+			castingability = spell?.system?.ability ?? main;
 		}
 
 		return [

--- a/scripts/dnd5e/InnateSpellbookPrep.js
+++ b/scripts/dnd5e/InnateSpellbookPrep.js
@@ -20,9 +20,9 @@ export default class InnateSpellbookPrep {
 	 * @return {object} The completed innate spellbook 
 	 * @memberof InnateSpellbookPrep
 	 */
-	prepare() {                                              // We need to completely re-organize the spellbook for an innate spellcaster
-		for (let level of this.spellbook) {                  // Spellbook is seperated into sections based on level, though all the innate spells are lumped together, we still want to check all the sections.
-			if (level.prop !== "innate") continue;           // We don't care about sections that aren't marked as innate though
+	prepare() {                                              					// We need to completely re-organize the spellbook for an innate spellcaster
+		for (let level of this.spellbook) {                  					// Spellbook is seperated into sections based on level, though all the innate spells are lumped together, we still want to check all the sections.
+			if (!["innate", "atwill"].includes(level.prop) && !level.spells.some(s => s.getFlag("dnd5e", "cachedFor"))) continue;           // We don't care about sections that aren't marked as innate though
 			this.prepareSpellLevel(level);
 		}
 
@@ -69,7 +69,11 @@ export default class InnateSpellbookPrep {
 	 */
 	sortSpell(spell) {
 		// Max uses is what we are going to end up sorting the spellbook by.
-		this.getPage(spell.system.uses.max).spells.push(spell);
+		let uses = spell.system.uses.max;
+		if (spell.getFlag("dnd5e", "cachedFor")) {
+			uses = fromUuidSync(spell.getFlag("dnd5e", "cachedFor"), {relative: this.sheet.object}).uses.max;
+		}
+		this.getPage(uses).spells.push(spell);
 	}
 
 	/**

--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -94,10 +94,10 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 
 		for (let fk of Object.keys(data.features)) {
 			for (let item of data.features[fk].items) {
-				const value = await TextEditor.enrichHTML(item.system.description.value, { secrets: (data.owner && !data.flags["hidden-secrets"])});
+				const value = await TextEditor.enrichHTML(item.system.description.value, { relativeTo: item, secrets: (data.owner && !data.flags["hidden-secrets"])});
 				item.enrichedValue = value;
-				item.rechargeValue = isDndV4OrNewer() ? item.system.uses.recovery.find(r => r.period === "recharge")?.formula : item.system.recharge?.value;
-				item.activationCost = isDndV4OrNewer() ? item.system.activities.find(a => a.activation.value)?.activation.value : item.system.activation?.cost;
+				item.rechargeValue = isDndV4OrNewer() ? item.system.uses?.recovery.find(r => r.period === "recharge")?.formula : item.system.recharge?.value;
+				item.activationCost = isDndV4OrNewer() ? item.system.activities?.find(a => a.activation.value)?.activation.value : item.system.activation?.cost;
 			}
 		}
 
@@ -130,6 +130,7 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 		data.themes = this.themes;
 
 		data.sourceStringId = game.i18n.has("DND5E.Source") ? "DND5E.Source" : "DND5E.SOURCE.FIELDS.source.label";
+		data.legActTitleId = game.i18n.has("DND5E.LegAct") ? "DND5E.LegAct" : "DND5E.NPC.SECTIONS.LegendaryActions";
 
 		this.templateData = data;
 		return data;
@@ -604,7 +605,10 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 	}
 	prepAbilities(data) {
 		Object.entries(data.abilities)?.forEach(
-			([id, ability]) => ability.abbr = game.i18n.localize("MOBLOKS5E.Abbr" + id)
+			([id, ability]) => {
+				ability.abbr = game.i18n.localize("MOBLOKS5E.Abbr" + id);
+				ability.saveValue = ability.save.value ?? ability.save;
+			}
 		)
 	}
 	/**

--- a/templates/dnd5e/parts/header/attributes/saves.hbs
+++ b/templates/dnd5e/parts/header/attributes/saves.hbs
@@ -6,7 +6,7 @@
 			<li class="saving-throw {{#if ability.proficient}}proficient{{/if}}" data-ability="{{id}}"
 				title="{{ability.label}}">
 				<span class="ability-title">{{ability.label}}</span>
-				<span>{{numberFormat ability.save decimals=0 sign=true}}</span>{{~" "~}}
+				<span>{{numberFormat ability.saveValue decimals=0 sign=true}}</span>{{~" "~}}
 			</li>
 		{{/each}}
 		</ul>
@@ -17,7 +17,7 @@
 	{{#if (or ability.proficient @root.flags.show-not-prof)}}
 		<li class="saving-throw {{#if ability.proficient}}proficient{{/if}}" data-ability="{{id}}" title="{{ability.label}}">
 			<span class="ability-title">{{ability.abbr}}</span>
-			<span>{{numberFormat ability.save decimals=0 sign=true}}</span>{{~" "~}}
+			<span>{{numberFormat ability.saveValue decimals=0 sign=true}}</span>{{~" "~}}
 		</li>
 	{{/if}}
 {{/each}}

--- a/templates/dnd5e/parts/main/legendaryActs.hbs
+++ b/templates/dnd5e/parts/main/legendaryActs.hbs
@@ -1,5 +1,5 @@
 {{#> "modules/monsterblock/templates/dnd5e/collapsibleSection.hbs"
-	title="DND5E.LegAct"
+	title=legActTitleId
 	section="legendary"
 	resource-key="system.resources.legact"}}
 	<p class="legendary-description">


### PR DESCRIPTION
- Fixed description enrichment (#241);
- Fixed Legendary Actions section title (#242);
- Fixed old reference to .data and additional deprecations (#243);
- Fixed reference to ability.save (now .save.value in 4.x) (#245);
- Fixed issue with inventory items (#247).
- Improved innate spellcasting management with initial support for cast activities (like in the MM2024) (#246).

Hopefully submitting a PR on a PR branch is not too weird. 
I will add a note in #246 to explain a little more about that one, but part of the problem there is a new style of creating spellcasting features (with cast activities inside, instead of actuall spell items), with a current system limitation preventing the spellbook to be populated. The changes made here still bring us in a better place to work with that.